### PR TITLE
M3-119 개인전 픽셀 표시하는 화면 만들기

### DIFF
--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -20,7 +20,7 @@ class MapController extends GetxController {
   static const int defaultUserId = 1;
 
   final Location location = Location();
-  late final String darkMapStyle;
+  late final String mapStyle;
   Completer<GoogleMapController> completer = Completer();
 
   late LocationData currentLocation;
@@ -70,7 +70,7 @@ class MapController extends GetxController {
   }
 
   Future<void> _loadMapStyle() async {
-    darkMapStyle = await rootBundle.loadString(darkMapStylePath);
+    mapStyle = await rootBundle.loadString(darkMapStylePath);
   }
 
   void _updateMarkerPosition(LocationData newLocation, String markerId) {

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -5,10 +5,10 @@ import 'package:get/get.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:location/location.dart';
 
-import '../service/individual_pixel_service.dart';
+import '../service/pixel_service.dart';
 
 class MapController extends GetxController {
-  final IndividualPixelService individualPixelService = IndividualPixelService();
+  final PixelService individualPixelService = PixelService();
 
   static const String darkMapStylePath = 'assets/map_style/dark_map_style.txt';
   static const String userMarkerId = 'USER';

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -1,17 +1,23 @@
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:location/location.dart';
 
+import '../models/individual_pixel.dart';
 import '../service/pixel_service.dart';
+import '../widgets/pixel.dart';
 
 class MapController extends GetxController {
   final PixelService individualPixelService = PixelService();
 
   static const String darkMapStylePath = 'assets/map_style/dark_map_style.txt';
   static const String userMarkerId = 'USER';
+  static const double latPerPixel = 0.000724;
+  static const double lonPerPixel = 0.000909;
+  static const int defaultUserId = 1;
 
   final Location location = Location();
   late final String darkMapStyle;
@@ -19,6 +25,7 @@ class MapController extends GetxController {
 
   late LocationData currentLocation;
 
+  RxList<Pixel> pixels = <Pixel>[].obs;
   RxList<Marker> markers = <Marker>[].obs;
   RxBool isLoading = true.obs;
 
@@ -27,9 +34,10 @@ class MapController extends GetxController {
     super.onInit();
     await _loadMapStyle();
     await updateCurrentLocation();
+    await _createIndividualPixel();
     _createUserMarker();
     _trackUserLocation();
-    await individualPixelService.getIndividualPixels(currentLatitude: currentLocation.latitude!, currentLongitude: currentLocation.longitude!);
+    _trackPixels();
   }
 
   void _trackUserLocation() {
@@ -68,5 +76,39 @@ class MapController extends GetxController {
   void _updateMarkerPosition(LocationData newLocation, String markerId) {
     markers.removeWhere((marker) => marker.markerId.value == markerId);
     _addMarker(LatLng(newLocation.latitude!, newLocation.longitude!), markerId);
+  }
+
+  Future<void> _createIndividualPixel() async {
+    List<IndividualPixel> individualPixelList = await individualPixelService.getIndividualPixels(
+        currentLatitude: currentLocation.latitude!,
+        currentLongitude: currentLocation.longitude!,
+    );
+
+    pixels = [
+      for(var pixel in individualPixelList)
+        Pixel(
+            x: pixel.x,
+            y: pixel.y,
+            pixelId: pixel.pixelId,
+            polygonId: pixel.pixelId.toString(),
+            points: _getRectangleFromLatLng(topLeftPoint: LatLng(pixel.latitude, pixel.longitude)),
+            fillColor: (pixel.userId == defaultUserId) ? Colors.blue.withOpacity(0.3) : Colors.red.withOpacity(0.3),
+            strokeColor: (pixel.userId == defaultUserId) ? Colors.blue : Colors.red,
+            strokeWidth: 1,
+        ),
+    ].obs;
+  }
+
+  List<LatLng> _getRectangleFromLatLng({required LatLng topLeftPoint}) {
+    return List<LatLng>.of({
+      LatLng(topLeftPoint.latitude, topLeftPoint.longitude),
+      LatLng(topLeftPoint.latitude, topLeftPoint.longitude + lonPerPixel),
+      LatLng(topLeftPoint.latitude - latPerPixel, topLeftPoint.longitude + lonPerPixel),
+      LatLng(topLeftPoint.latitude - latPerPixel, topLeftPoint.longitude),
+    });
+  }
+
+  void _trackPixels() {
+
   }
 }

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -34,7 +34,7 @@ class MapController extends GetxController {
     super.onInit();
     await _loadMapStyle();
     await updateCurrentLocation();
-    await _createIndividualPixel();
+    await _updateIndividualPixel();
     _createUserMarker();
     _trackUserLocation();
     _trackPixels();
@@ -78,7 +78,7 @@ class MapController extends GetxController {
     _addMarker(LatLng(newLocation.latitude!, newLocation.longitude!), markerId);
   }
 
-  Future<void> _createIndividualPixel() async {
+  Future<void> _updateIndividualPixel() async {
     List<IndividualPixel> individualPixelList = await individualPixelService.getIndividualPixels(
         currentLatitude: currentLocation.latitude!,
         currentLongitude: currentLocation.longitude!,

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -109,6 +109,8 @@ class MapController extends GetxController {
   }
 
   void _trackPixels() {
-
+    Timer.periodic(const Duration(seconds: 30), (timer) {
+      _updateIndividualPixel();
+    });
   }
 }

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -33,7 +33,7 @@ class MapScreen extends StatelessWidget {
               onMapCreated: (GoogleMapController ctrl) {
                 mapController.completer.complete(ctrl);
               },
-              style: mapController.darkMapStyle,
+              style: mapController.mapStyle,
               markers: Set<Marker>.of(mapController.markers),
               polygons: Set<Polygon>.of(mapController.pixels),
             );

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -35,6 +35,7 @@ class MapScreen extends StatelessWidget {
               },
               style: mapController.darkMapStyle,
               markers: Set<Marker>.of(mapController.markers),
+              polygons: Set<Polygon>.of(mapController.pixels),
             );
           }
         }),

--- a/lib/service/pixel_service.dart
+++ b/lib/service/pixel_service.dart
@@ -3,15 +3,15 @@ import 'package:dio/dio.dart';
 import '../models/individual_pixel.dart';
 import '../utils/dio_service.dart';
 
-class IndividualPixelService {
-  static final IndividualPixelService _instance =
-      IndividualPixelService._internal();
+class PixelService {
+  static final PixelService _instance =
+      PixelService._internal();
 
   final Dio dio = DioService().getDio();
 
-  IndividualPixelService._internal();
+  PixelService._internal();
 
-  factory IndividualPixelService() {
+  factory PixelService() {
     return _instance;
   }
 

--- a/lib/widgets/pixel.dart
+++ b/lib/widgets/pixel.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+class Pixel extends Polygon {
+  final int x;
+  final int y;
+  final int pixelId;
+
+  Pixel({
+    required this.x,
+    required this.y,
+    required this.pixelId,
+    required String polygonId,
+    super.points,
+    super.geodesic,
+    super.visible,
+    super.fillColor = const Color(0x00000000),
+    super.strokeColor = const Color(0x00000000),
+    super.strokeWidth = 0,
+    List<PatternItem> patterns = const <PatternItem>[],
+    super.consumeTapEvents,
+    super.onTap,
+  }) : super(
+    polygonId: PolygonId(polygonId),
+  );
+}


### PR DESCRIPTION
## 작업 내용*
- 개인전 픽셀 표시 구현 완료
## 고민한 내용*
- 구글맵의 Polygon 자료형을 상속하는 Pixel 클래스를 만들어 활용함
- _updateIndividaulPixel()에 Future와 await을 사용하지 않으면 지도 초기화 몇 초 뒤에 픽셀이 나타나는 문제가 발생함.
- 시간을 측정해보니 네트워크 통신, 리스트 연산 등은 빠르게 이루어짐.
- 픽셀이 받아와 진 후 gps 수신이 이루어질 때 마커의 이동하고 같이 렌더링되어서 지연이 있었던 것 같음.
- await, Future를 사용하니 바로 렌더링 됨
- 기술적 고민
## 리뷰 요구사항
- 픽셀 그리는 로직이 매끄러운지 봐주시면 감사하겠습니다
- 확장성을 고려한 설계를 하고 싶었는데 함수를 더 분리하면 좋을지 조언 부탁드립니다.
## 스크린샷
<img src="https://github.com/SWM-M3PRO/GroundFlip-FE/assets/62949434/0a1989fe-e145-4f78-9185-819ab1589fe2.png" width="300" height="600"/>
<img src="https://github.com/SWM-M3PRO/GroundFlip-FE/assets/62949434/8e44ffc9-b297-4bbc-a089-34815cc8c395.png" width="300" height="600"/>