### PR TITLE
M3-121 픽셀 차지하는 요청 보내는 서비스 구현

### DIFF
--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -5,10 +5,10 @@ import 'package:get/get.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:location/location.dart';
 
-import '../service/individual_pixel_service.dart';
+import '../service/pixel_service.dart';
 
 class MapController extends GetxController {
-  final IndividualPixelService individualPixelService = IndividualPixelService();
+  final PixelService individualPixelService = PixelService();
 
   static const String darkMapStylePath = 'assets/map_style/dark_map_style.txt';
   static const String userMarkerId = 'USER';

--- a/lib/models/pixel_occupy_request.dart
+++ b/lib/models/pixel_occupy_request.dart
@@ -1,10 +1,10 @@
-class PixelRequest {
+class PixelOccupyRequest {
   final int userId;
   final int? communityId;
   final int x;
   final int y;
 
-  PixelRequest({
+  PixelOccupyRequest({
     required this.userId,
     this.communityId,
     required this.x,

--- a/lib/models/pixel_request.dart
+++ b/lib/models/pixel_request.dart
@@ -1,0 +1,20 @@
+class PixelRequest {
+  final int userId;
+  final int? communityId;
+  final int x;
+  final int y;
+
+  PixelRequest({
+    required this.userId,
+    this.communityId,
+    required this.x,
+    required this.y,
+  });
+
+  Map<String, dynamic> toJson() => {
+        "userId": userId,
+        "communityId": communityId,
+        "x": x,
+        "y": y,
+      };
+}

--- a/lib/service/pixel_service.dart
+++ b/lib/service/pixel_service.dart
@@ -1,7 +1,7 @@
 import 'package:dio/dio.dart';
 
 import '../models/individual_pixel.dart';
-import '../models/pixel_request.dart';
+import '../models/pixel_occupy_request.dart';
 import '../utils/dio_service.dart';
 
 class PixelService {
@@ -44,17 +44,22 @@ class PixelService {
   }) async {
     Map<String, int> relativeCoordinate =
         _computeRelativeCoordinateByCoordinate(
-            currentLatitude, currentLongitude,);
-    PixelRequest pixelRequest = PixelRequest(
-        userId: userId,
-        x: relativeCoordinate['x']!,
-        y: relativeCoordinate['y']!,
-        communityId: communityId,);
+      currentLatitude,
+      currentLongitude,
+    );
+    PixelOccupyRequest pixelRequest = PixelOccupyRequest(
+      userId: userId,
+      x: relativeCoordinate['x']!,
+      y: relativeCoordinate['y']!,
+      communityId: communityId,
+    );
     await dio.post('/pixels', data: pixelRequest.toJson());
   }
 
   Map<String, int> _computeRelativeCoordinateByCoordinate(
-      double latitude, double longitude,) {
+    double latitude,
+    double longitude,
+  ) {
     int x = ((upperLeftLatitude - latitude) / latitudePerPixel).floor();
     int y = ((longitude - upperLeftLongitude) / longitudePerPixel).floor();
     return {'x': x, 'y': y};

--- a/lib/service/pixel_service.dart
+++ b/lib/service/pixel_service.dart
@@ -1,11 +1,11 @@
 import 'package:dio/dio.dart';
 
 import '../models/individual_pixel.dart';
+import '../models/pixel_request.dart';
 import '../utils/dio_service.dart';
 
 class PixelService {
-  static final PixelService _instance =
-      PixelService._internal();
+  static final PixelService _instance = PixelService._internal();
 
   final Dio dio = DioService().getDio();
 
@@ -30,5 +30,28 @@ class PixelService {
     );
 
     return IndividualPixel.listFromJson(response.data['data']);
+  }
+
+  void occupyPixel({
+    required int userId,
+    required double currentLatitude,
+    required double currentLongitude,
+    int? communityId,
+  }) async {
+    Map<String, int> relativeCoordinate =
+        _computeRelativeCoordinateByCoordinate(
+            currentLatitude, currentLongitude);
+    PixelRequest pixelRequest = PixelRequest(
+        userId: userId,
+        x: relativeCoordinate['x']!,
+        y: relativeCoordinate['y']!,
+        communityId: communityId);
+    await dio.post('/pixels', data: pixelRequest.toJson());
+  }
+
+  Map<String, int> _computeRelativeCoordinateByCoordinate(
+      double latitude, double longitude) {
+    //ToDo 구현하기
+    return {'x': 1, 'y': 1};
   }
 }

--- a/lib/service/pixel_service.dart
+++ b/lib/service/pixel_service.dart
@@ -6,6 +6,10 @@ import '../utils/dio_service.dart';
 
 class PixelService {
   static final PixelService _instance = PixelService._internal();
+  static const double latitudePerPixel = 0.000724;
+  static const double longitudePerPixel = 0.000909;
+  static const double upperLeftLatitude = 37.666508;
+  static const double upperLeftLongitude = 126.85411700000002;
 
   final Dio dio = DioService().getDio();
 
@@ -32,7 +36,7 @@ class PixelService {
     return IndividualPixel.listFromJson(response.data['data']);
   }
 
-  void occupyPixel({
+  Future<void> occupyPixel({
     required int userId,
     required double currentLatitude,
     required double currentLongitude,
@@ -40,18 +44,19 @@ class PixelService {
   }) async {
     Map<String, int> relativeCoordinate =
         _computeRelativeCoordinateByCoordinate(
-            currentLatitude, currentLongitude);
+            currentLatitude, currentLongitude,);
     PixelRequest pixelRequest = PixelRequest(
         userId: userId,
         x: relativeCoordinate['x']!,
         y: relativeCoordinate['y']!,
-        communityId: communityId);
+        communityId: communityId,);
     await dio.post('/pixels', data: pixelRequest.toJson());
   }
 
   Map<String, int> _computeRelativeCoordinateByCoordinate(
-      double latitude, double longitude) {
-    //ToDo 구현하기
-    return {'x': 1, 'y': 1};
+      double latitude, double longitude,) {
+    int x = ((upperLeftLatitude - latitude) / latitudePerPixel).floor();
+    int y = ((longitude - upperLeftLongitude) / longitudePerPixel).floor();
+    return {'x': x, 'y': y};
   }
 }

--- a/lib/service/pixel_service.dart
+++ b/lib/service/pixel_service.dart
@@ -3,15 +3,15 @@ import 'package:dio/dio.dart';
 import '../models/individual_pixel.dart';
 import '../utils/dio_service.dart';
 
-class IndividualPixelService {
-  static final IndividualPixelService _instance =
-      IndividualPixelService._internal();
+class PixelService {
+  static final PixelService _instance =
+      PixelService._internal();
 
   final Dio dio = DioService().getDio();
 
-  IndividualPixelService._internal();
+  PixelService._internal();
 
-  factory IndividualPixelService() {
+  factory PixelService() {
     return _instance;
   }
 


### PR DESCRIPTION
## 작업 내용*
- 픽셀을 차지하는 요청을 보내는 기능 구현
- 현재 위도 경도로 부터 속해있는 픽셀 번호 추출하는 기능 구현
## 고민한 내용*
### 현재 위도 경도로 부터 속해있는 픽셀 번호 추출하는 기능
```
  Map<String, int> _computeRelativeCoordinateByCoordinate(
      double latitude, double longitude,) {
    int x = ((upperLeftLatitude - latitude) / latitudePerPixel).floor();
    int y = ((longitude - upperLeftLongitude) / longitudePerPixel).floor();
    return {'x': x, 'y': y};
  }
```

픽셀들의 시작이 되는 0,0 픽셀의 위도 경도를 upperLeft 로 저장해두고 현재 위도 경도를 빼는 방식으로 구현했다. x,y 값은 왼쪽위로부터의 순서이기에 픽셀 간격으로 나누어주었다. 또한 현재 위치기준 왼쪽 위의 픽셀 번호를 받아야하기에 계산된 값에 내림을 해서 구했다.

## 리뷰 요구사항
- 리뷰할 때 중점적으로 봐줬으면 하는 내용들
## 스크린샷