### PR TITLE
M3-142 픽셀을 차지하는 기능 구현

### DIFF
--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -73,7 +73,7 @@ class MapController extends GetxController {
 
   void _createUserMarker() {
     _addMarker(LatLng(currentLocation.latitude!, currentLocation.longitude!),
-        userMarkerId);
+        userMarkerId,);
   }
 
   void _addMarker(LatLng position, String markerId) {
@@ -108,7 +108,7 @@ class MapController extends GetxController {
           pixelId: pixel.pixelId,
           polygonId: pixel.pixelId.toString(),
           points: _getRectangleFromLatLng(
-              topLeftPoint: LatLng(pixel.latitude, pixel.longitude)),
+              topLeftPoint: LatLng(pixel.latitude, pixel.longitude),),
           fillColor: (pixel.userId == defaultUserId)
               ? Colors.blue.withOpacity(0.3)
               : Colors.red.withOpacity(0.3),
@@ -124,7 +124,7 @@ class MapController extends GetxController {
       LatLng(topLeftPoint.latitude, topLeftPoint.longitude),
       LatLng(topLeftPoint.latitude, topLeftPoint.longitude + lonPerPixel),
       LatLng(topLeftPoint.latitude - latPerPixel,
-          topLeftPoint.longitude + lonPerPixel),
+          topLeftPoint.longitude + lonPerPixel,),
       LatLng(topLeftPoint.latitude - latPerPixel, topLeftPoint.longitude),
     });
   }
@@ -147,7 +147,7 @@ class MapController extends GetxController {
   isPixelChanged() {
     Map<String, int> currentPixel =
         pixelService.computeRelativeCoordinateByCoordinate(
-            currentLocation.latitude!, currentLocation.longitude!);
+            currentLocation.latitude!, currentLocation.longitude!,);
     return latestPixel['x'] != currentPixel['x'] ||
         latestPixel['y'] != currentPixel['y'];
   }

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -11,7 +11,7 @@ import '../service/pixel_service.dart';
 import '../widgets/pixel.dart';
 
 class MapController extends GetxController {
-  final PixelService individualPixelService = PixelService();
+  final PixelService pixelService = PixelService();
 
   static const String darkMapStylePath = 'assets/map_style/dark_map_style.txt';
   static const String userMarkerId = 'USER';
@@ -34,6 +34,7 @@ class MapController extends GetxController {
     super.onInit();
     await _loadMapStyle();
     await updateCurrentLocation();
+    await occupyPixel();
     await _updateIndividualPixel();
     _createUserMarker();
     _trackUserLocation();
@@ -58,7 +59,8 @@ class MapController extends GetxController {
   }
 
   void _createUserMarker() {
-    _addMarker(LatLng(currentLocation.latitude!, currentLocation.longitude!), userMarkerId);
+    _addMarker(LatLng(currentLocation.latitude!, currentLocation.longitude!),
+        userMarkerId);
   }
 
   void _addMarker(LatLng position, String markerId) {
@@ -79,22 +81,27 @@ class MapController extends GetxController {
   }
 
   Future<void> _updateIndividualPixel() async {
-    List<IndividualPixel> individualPixelList = await individualPixelService.getIndividualPixels(
-        currentLatitude: currentLocation.latitude!,
-        currentLongitude: currentLocation.longitude!,
+    List<IndividualPixel> individualPixelList =
+        await pixelService.getIndividualPixels(
+      currentLatitude: currentLocation.latitude!,
+      currentLongitude: currentLocation.longitude!,
     );
 
     pixels = [
-      for(var pixel in individualPixelList)
+      for (var pixel in individualPixelList)
         Pixel(
-            x: pixel.x,
-            y: pixel.y,
-            pixelId: pixel.pixelId,
-            polygonId: pixel.pixelId.toString(),
-            points: _getRectangleFromLatLng(topLeftPoint: LatLng(pixel.latitude, pixel.longitude)),
-            fillColor: (pixel.userId == defaultUserId) ? Colors.blue.withOpacity(0.3) : Colors.red.withOpacity(0.3),
-            strokeColor: (pixel.userId == defaultUserId) ? Colors.blue : Colors.red,
-            strokeWidth: 1,
+          x: pixel.x,
+          y: pixel.y,
+          pixelId: pixel.pixelId,
+          polygonId: pixel.pixelId.toString(),
+          points: _getRectangleFromLatLng(
+              topLeftPoint: LatLng(pixel.latitude, pixel.longitude)),
+          fillColor: (pixel.userId == defaultUserId)
+              ? Colors.blue.withOpacity(0.3)
+              : Colors.red.withOpacity(0.3),
+          strokeColor:
+              (pixel.userId == defaultUserId) ? Colors.blue : Colors.red,
+          strokeWidth: 1,
         ),
     ].obs;
   }
@@ -103,7 +110,8 @@ class MapController extends GetxController {
     return List<LatLng>.of({
       LatLng(topLeftPoint.latitude, topLeftPoint.longitude),
       LatLng(topLeftPoint.latitude, topLeftPoint.longitude + lonPerPixel),
-      LatLng(topLeftPoint.latitude - latPerPixel, topLeftPoint.longitude + lonPerPixel),
+      LatLng(topLeftPoint.latitude - latPerPixel,
+          topLeftPoint.longitude + lonPerPixel),
       LatLng(topLeftPoint.latitude - latPerPixel, topLeftPoint.longitude),
     });
   }
@@ -112,5 +120,13 @@ class MapController extends GetxController {
     Timer.periodic(const Duration(seconds: 30), (timer) {
       _updateIndividualPixel();
     });
+  }
+
+  Future<void> occupyPixel() async {
+    await pixelService.occupyPixel(
+      userId: defaultUserId,
+      currentLatitude: currentLocation.latitude!,
+      currentLongitude: currentLocation.longitude!,
+    );
   }
 }

--- a/lib/service/pixel_service.dart
+++ b/lib/service/pixel_service.dart
@@ -42,8 +42,7 @@ class PixelService {
     required double currentLongitude,
     int? communityId,
   }) async {
-    Map<String, int> relativeCoordinate =
-        _computeRelativeCoordinateByCoordinate(
+    Map<String, int> relativeCoordinate = computeRelativeCoordinateByCoordinate(
       currentLatitude,
       currentLongitude,
     );
@@ -56,7 +55,7 @@ class PixelService {
     await dio.post('/pixels', data: pixelRequest.toJson());
   }
 
-  Map<String, int> _computeRelativeCoordinateByCoordinate(
+  Map<String, int> computeRelativeCoordinateByCoordinate(
     double latitude,
     double longitude,
   ) {
@@ -64,5 +63,4 @@ class PixelService {
     int y = ((longitude - upperLeftLongitude) / longitudePerPixel).floor();
     return {'x': x, 'y': y};
   }
-
 }


### PR DESCRIPTION
## 작업 내용*
- 위치가 변경될 때 마다 위치해있던 픽셀이 변경되는지 감지하는 기능 구현
- 방문한 픽셀을 차지하는 요청을 보내고 화면에 방문처리하는 기능 구현
## 고민한 내용*
### 픽셀을 차지 했을때 화면에 표시하는 부분
픽셀을 차지하는 요청을 보내고 해당 요청이 성공하면 해당 픽셀을 픽셀 리스트에 넣어서 표시 할까 고민해보았는데 그렇게 되면 중복된 픽셀이 들어갈수도 있고 모드 마다 로직 변경이 필요한 단점이 있었다.

그래서 픽셀 차지하는 요청이 성공하면 updateIndividualPixel 을 호출하여 주변의 픽셀을 전부 변경하는 방식을 사용하였다.

## 리뷰 요구사항
- 리뷰할 때 중점적으로 봐줬으면 하는 내용들
## 스크린샷