### PR TITLE
M3-116 누적 픽셀 표시하는 화면 만들기

### DIFF
--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -26,8 +26,8 @@ class MapController extends GetxController {
 
   late LocationData currentLocation;
   late Map<String, int> latestPixel;
-  PixelMode pixelMode = PixelMode.individualHistory;
 
+  Rx<PixelMode> currentPixelMode = PixelMode.individualHistory.obs;
   RxList<Pixel> pixels = <Pixel>[].obs;
   RxList<Marker> markers = <Marker>[].obs;
   RxBool isLoading = true.obs;
@@ -102,10 +102,10 @@ class MapController extends GetxController {
         userId: defaultUserId,
     );
 
-    pixels = [
+    pixels.assignAll([
       for(var pixel in individualHistoryPixels)
         Pixel.fromIndividualHistoryPixel(pixel: pixel),
-    ].obs;
+    ]);
   }
 
   Future<void> _updateIndividualModePixel() async {
@@ -114,10 +114,10 @@ class MapController extends GetxController {
       currentLongitude: currentLocation.longitude!,
     );
 
-    pixels = [
+    pixels.assignAll([
       for(var pixel in individualModePixels)
         Pixel.fromIndividualModePixel(pixel: pixel, isMyPixel: (pixel.userId == defaultUserId)),
-    ].obs;
+    ]);
   }
 
   void _trackPixels() {
@@ -127,7 +127,7 @@ class MapController extends GetxController {
   }
 
   void _updatePixels() {
-    switch (pixelMode) {
+    switch (currentPixelMode.value) {
       case PixelMode.individualMode:
         _updateIndividualModePixel();
         break;
@@ -154,5 +154,10 @@ class MapController extends GetxController {
             currentLocation.latitude!, currentLocation.longitude!,);
     return latestPixel['x'] != currentPixel['x'] ||
         latestPixel['y'] != currentPixel['y'];
+  }
+
+  void changePixelMode(String pixelModeKrName) {
+    currentPixelMode.value = PixelMode.fromKrName(pixelModeKrName);
+    _updatePixels();
   }
 }

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -5,7 +5,7 @@ import 'package:get/get.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:location/location.dart';
 
-import '../enum/pixel_mode.dart';
+import '../enums/pixel_mode.dart';
 import '../models/individual_history_pixel.dart';
 import '../models/individual_mode_pixel.dart';
 import '../service/pixel_service.dart';

--- a/lib/enum/pixel_mode.dart
+++ b/lib/enum/pixel_mode.dart
@@ -1,5 +1,9 @@
 enum PixelMode {
-  individualMode,
-  individualHistory,
-  groupMode
+  individualMode(name : '개인전'),
+  individualHistory(name : '개인 기록'),
+  groupMode(name : '그룹전');
+
+  const PixelMode({required this.name});
+
+  final String name;
 }

--- a/lib/enum/pixel_mode.dart
+++ b/lib/enum/pixel_mode.dart
@@ -1,9 +1,14 @@
 enum PixelMode {
-  individualMode(name : '개인전'),
-  individualHistory(name : '개인 기록'),
-  groupMode(name : '그룹전');
+  individualMode(krName : '개인전'),
+  individualHistory(krName : '개인 기록'),
+  groupMode(krName : '그룹전');
 
-  const PixelMode({required this.name});
+  const PixelMode({required this.krName});
 
-  final String name;
+  final String krName;
+
+  static PixelMode fromKrName(String krName) {
+    return PixelMode.values.firstWhere((mode) => mode.krName == krName,
+        orElse: () => throw ArgumentError('No enum value with krName $krName'));
+  }
 }

--- a/lib/enums/pixel_mode.dart
+++ b/lib/enums/pixel_mode.dart
@@ -1,14 +1,14 @@
 enum PixelMode {
-  individualMode(krName : '개인전'),
-  individualHistory(krName : '개인 기록'),
-  groupMode(krName : '그룹전');
+  individualMode(koreanName : '개인전'),
+  individualHistory(koreanName : '개인 기록'),
+  groupMode(koreanName : '그룹전');
 
-  const PixelMode({required this.krName});
+  const PixelMode({required this.koreanName});
 
-  final String krName;
+  final String koreanName;
 
   static PixelMode fromKrName(String krName) {
-    return PixelMode.values.firstWhere((mode) => mode.krName == krName,
+    return PixelMode.values.firstWhere((mode) => mode.koreanName == krName,
         orElse: () => throw ArgumentError('No enum value with krName $krName'),
     );
   }

--- a/lib/enums/pixel_mode.dart
+++ b/lib/enums/pixel_mode.dart
@@ -9,6 +9,7 @@ enum PixelMode {
 
   static PixelMode fromKrName(String krName) {
     return PixelMode.values.firstWhere((mode) => mode.krName == krName,
-        orElse: () => throw ArgumentError('No enum value with krName $krName'));
+        orElse: () => throw ArgumentError('No enum value with krName $krName'),
+    );
   }
 }

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1,6 +1,3 @@
-import 'dart:ffi';
-
-import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
@@ -10,7 +7,6 @@ import '../controllers/permission_controller.dart';
 import '../controllers/walking_controller.dart';
 import '../widgets/map/mode_change_button.dart';
 import '../widgets/map/step_stats.dart';
-import '../enum/pixel_mode.dart';
 
 class MapScreen extends StatelessWidget {
   const MapScreen({super.key});

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1,3 +1,6 @@
+import 'dart:ffi';
+
+import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
@@ -5,6 +8,9 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import '../controllers/map_controller.dart';
 import '../controllers/permission_controller.dart';
 import '../controllers/walking_controller.dart';
+import '../widgets/map/mode_change_button.dart';
+import '../widgets/map/step_stats.dart';
+import '../enum/pixel_mode.dart';
 
 class MapScreen extends StatelessWidget {
   const MapScreen({super.key});
@@ -42,46 +48,17 @@ class MapScreen extends StatelessWidget {
                 markers: Set<Marker>.of(mapController.markers),
                 polygons: Set<Polygon>.of(mapController.pixels),
               ),
-              Align(
-                alignment: Alignment.topRight,
-                child: Padding(
-                  padding: const EdgeInsets.only(
-                    right: 16.0,
-                    top: 60.0,
+              Column(
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(top: 65.0),
                   ),
-                  child: Container(
-                    width: 100.0,
-                    decoration: BoxDecoration(
-                      border: Border.all(color: Colors.grey),
-                      color: Colors.black54,
-                      borderRadius: const BorderRadius.all(
-                        Radius.circular(15),
-                      ),
-                    ),
-                    child: DropdownButtonHideUnderline(
-                      child: DropdownButton<String>(
-                        isExpanded: true,
-                        value: '개인전',
-                        onChanged: (String? newValue) {},
-                        items: <String>['개인전', '그룹전', '개인 기록']
-                            .map<DropdownMenuItem<String>>((String value) {
-                          return DropdownMenuItem<String>(
-                            value: value,
-                            child: Center(
-                              child: Text(
-                                value,
-                                style: TextStyle(
-                                  color: Colors.blue,
-                                ),
-                                textAlign: TextAlign.center,
-                              ),
-                            ),
-                          );
-                        }).toList(),
-                      ),
-                    ),
+                  ModeChangeButton(),
+                  const Padding(
+                    padding: EdgeInsets.only(bottom: 32),
+                    child: StepStats(),
                   ),
-                ),
+                ],
               ),
             ],
           );

--- a/lib/widgets/map/mode_change_button.dart
+++ b/lib/widgets/map/mode_change_button.dart
@@ -1,0 +1,68 @@
+import 'package:dropdown_button2/dropdown_button2.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../controllers/map_controller.dart';
+import '../../enum/pixel_mode.dart';
+
+class ModeChangeButton extends StatelessWidget {
+  const ModeChangeButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    var mapController = Get.find<MapController>();
+
+    return Expanded(
+      child: Align(
+        alignment: Alignment.topRight,
+        child: DropdownButtonHideUnderline(
+          child: DropdownButton2<String>(
+            alignment: Alignment.center,
+            isExpanded: true,
+            items: PixelMode.values
+                .map(
+                  (PixelMode pixelMode) => DropdownMenuItem<String>(
+                    value: pixelMode.krName,
+                    child: Text(
+                      pixelMode.krName,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+                )
+                .toList(),
+            onChanged: (pixelModeKrName) {
+              mapController.changePixelMode(pixelModeKrName!);
+            },
+            value: mapController.currentPixelMode.value.krName,
+            buttonStyleData: ButtonStyleData(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              height: 40,
+              width: 120,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(14),
+                color: Colors.blueAccent,
+              ),
+            ),
+            dropdownStyleData: DropdownStyleData(
+              maxHeight: 200,
+              width: 120,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(14),
+                color: Colors.blueAccent,
+              ),
+              scrollbarTheme: ScrollbarThemeData(
+                radius: const Radius.circular(40),
+              ),
+            ),
+            menuItemStyleData: const MenuItemStyleData(
+              height: 40,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/map/mode_change_button.dart
+++ b/lib/widgets/map/mode_change_button.dart
@@ -22,9 +22,9 @@ class ModeChangeButton extends StatelessWidget {
             items: PixelMode.values
                 .map(
                   (PixelMode pixelMode) => DropdownMenuItem<String>(
-                    value: pixelMode.krName,
+                    value: pixelMode.koreanName,
                     child: Text(
-                      pixelMode.krName,
+                      pixelMode.koreanName,
                       style: const TextStyle(
                         fontSize: 14,
                         color: Colors.white,
@@ -36,7 +36,7 @@ class ModeChangeButton extends StatelessWidget {
             onChanged: (pixelModeKrName) {
               mapController.changePixelMode(pixelModeKrName!);
             },
-            value: mapController.currentPixelMode.value.krName,
+            value: mapController.currentPixelMode.value.koreanName,
             buttonStyleData: ButtonStyleData(
               padding: EdgeInsets.symmetric(horizontal: 16),
               height: 40,

--- a/lib/widgets/map/mode_change_button.dart
+++ b/lib/widgets/map/mode_change_button.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../controllers/map_controller.dart';
-import '../../enum/pixel_mode.dart';
+import '../../enums/pixel_mode.dart';
 
 class ModeChangeButton extends StatelessWidget {
   const ModeChangeButton({super.key});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.3+1"
+  dropdown_button2:
+    dependency: "direct main"
+    description:
+      name: dropdown_button2
+      sha256: b0fe8d49a030315e9eef6c7ac84ca964250155a6224d491c1365061bc974a9e1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.9"
   equatable:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_config: ^2.0.2
   health: ^10.2.0
   fl_chart: ^0.68.0
+  dropdown_button2: ^2.3.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 작업 내용*
- 개인전 픽셀 표시 구현
- 모드 변경 버튼 구현
## 고민한 내용*
- 픽셀 리스트를 변경할 때 일반 = 연산자가 아닌 assignAll()을 사용하니 렌더링이 즉시 됐다.
- 현재 선택된 모드는 드롭다운메뉴에 포함시키고 싶지 않았지만 동적으로 메뉴 리스트를 조절해야하는 어려움이 있어 아직 구현하지 못했다.
- 모드를 나타내는 enum에 대해 '개인전'과 같은 한글 이름을 나타내는 변수가 필요했다. 하지만 'name'이라는 변수명은 이미 Enum의 값을 불러오는 변수명으로 예약되어 있어 krName으로 설정했다.
- 드롭다운 버튼은 커스터마이징이 쉬운 dropdown_button2 라이브러리를 사용하였다.
## 리뷰 요구사항
- 변수명
- 드롭다운 메뉴도 위젯을 따로 분리하는게 좋을까요?

## 스크린샷
| ![스크린샷 2024-07-02 오후 1 46 44](https://github.com/SWM-M3PRO/GroundFlip-FE/assets/62949434/05f528a3-2d97-40ca-bd7c-08f93050755b) | ![스크린샷 2024-07-02 오후 1 47 12](https://github.com/SWM-M3PRO/GroundFlip-FE/assets/62949434/988785d0-c26a-4292-9078-9d075081f932) |
|----------|----------|