### PR TITLE
M3-146 개인 기록 픽셀을 클릭 했을 때 해당 픽셀에 대한 정보를 표시하는 기능 구현

### DIFF
--- a/lib/controllers/pixel_info_controller.dart
+++ b/lib/controllers/pixel_info_controller.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 
+import '../models/individual_history_pixel_info.dart';
 import '../models/individual_mode_pixel_info.dart';
 import '../service/pixel_service.dart';
 
@@ -10,5 +11,15 @@ class PixelInfoController extends GetxController {
     IndividualModePixelInfo individualModePixelInfo =
         await pixelService.getIndividualModePixelInfo(pixelId: pixelId);
     return individualModePixelInfo;
+  }
+
+  getIndividualHistoryPixelInfo(int pixelId, int userId) async {
+    IndividualHistoryPixelInfo individualHistoryPixelInfo =
+        await pixelService.getIndividualHistoryPixelInfo(
+            pixelId: pixelId,
+            userId: userId,
+        );
+
+    return individualHistoryPixelInfo;
   }
 }

--- a/lib/models/individual_history_pixel_info.dart
+++ b/lib/models/individual_history_pixel_info.dart
@@ -1,0 +1,35 @@
+
+class IndividualHistoryPixelInfo {
+  String? address;
+  int? addressNumber;
+  int? visitCount;
+  List<DateTime>? visitList;
+
+  IndividualHistoryPixelInfo(
+      {
+        this.address,
+        this.addressNumber,
+        this.visitCount,
+        this.visitList,
+      });
+
+  IndividualHistoryPixelInfo.fromJson(Map<String, dynamic> json) {
+    address = json['address'];
+    addressNumber = json['addressNumber'];
+    visitCount = json['visitCount'];
+    if (json['visitList'] != null) {
+      visitList = (json['visitList'] as List<dynamic>)
+          .map((item) => DateTime.parse(item))
+          .toList();
+    }
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'address': address,
+      'addressNumber': addressNumber,
+      'visitCount': visitCount,
+      'visitList': visitList?.map((item) => item.toIso8601String()).toList(),
+    };
+  }
+}

--- a/lib/service/pixel_service.dart
+++ b/lib/service/pixel_service.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 
 import '../models/individual_history_pixel.dart';
+import '../models/individual_history_pixel_info.dart';
 import '../models/individual_mode_pixel.dart';
 import '../models/individual_mode_pixel_info.dart';
 import '../models/pixel_occupy_request.dart';
@@ -10,8 +11,8 @@ class PixelService {
   static final PixelService _instance = PixelService._internal();
   static const double latitudePerPixel = 0.000724;
   static const double longitudePerPixel = 0.000909;
-  static const double upperLeftLatitude = 37.667516;
-  static const double upperLeftLongitude = 126.853603;
+  static const double upperLeftLatitude = 38.240675;
+  static const double upperLeftLongitude = 125.905952;
 
   final Dio dio = DioService().getDio();
 
@@ -65,6 +66,21 @@ class PixelService {
     );
 
     return IndividualModePixelInfo.fromJson(response.data['data']);
+  }
+
+
+  Future<IndividualHistoryPixelInfo> getIndividualHistoryPixelInfo({
+    required int pixelId,
+    required int userId,
+  }) async {
+    var response = await dio.get(
+      '/pixels/individual-history/$pixelId',
+      queryParameters: {
+        'user-id' : userId,
+      },
+    );
+
+    return IndividualHistoryPixelInfo.fromJson(response.data['data']);
   }
 
   Future<void> occupyPixel({

--- a/lib/widgets/map/individual_history_pixel_info_bottom_sheet.dart
+++ b/lib/widgets/map/individual_history_pixel_info_bottom_sheet.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+import '../../models/individual_history_pixel_info.dart';
+
+class IndividualHistoryPixelInfoBottomSheet extends StatelessWidget {
+  const IndividualHistoryPixelInfoBottomSheet({super.key, required this.pixelInfo});
+
+  final IndividualHistoryPixelInfo pixelInfo;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: Color(0xFF374957),
+        borderRadius: BorderRadius.only(
+          topRight: Radius.circular(20),
+          topLeft: Radius.circular(20),
+        ),
+      ),
+
+      child: SizedBox(
+        height: 400,
+        width: 380,
+      ),
+    );
+  }
+}

--- a/lib/widgets/map/individual_history_pixel_info_bottom_sheet.dart
+++ b/lib/widgets/map/individual_history_pixel_info_bottom_sheet.dart
@@ -5,7 +5,7 @@ import 'individual_visit_history_list_view.dart';
 
 class IndividualHistoryPixelInfoBottomSheet extends StatelessWidget {
   const IndividualHistoryPixelInfoBottomSheet(
-      {super.key, required this.pixelInfo});
+      {super.key, required this.pixelInfo,});
 
   final IndividualHistoryPixelInfo pixelInfo;
 

--- a/lib/widgets/map/individual_history_pixel_info_bottom_sheet.dart
+++ b/lib/widgets/map/individual_history_pixel_info_bottom_sheet.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 
 import '../../models/individual_history_pixel_info.dart';
+import 'individual_visit_history_list_view.dart';
 
 class IndividualHistoryPixelInfoBottomSheet extends StatelessWidget {
-  const IndividualHistoryPixelInfoBottomSheet({super.key, required this.pixelInfo});
+  const IndividualHistoryPixelInfoBottomSheet(
+      {super.key, required this.pixelInfo});
 
   final IndividualHistoryPixelInfo pixelInfo;
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -16,10 +19,41 @@ class IndividualHistoryPixelInfoBottomSheet extends StatelessWidget {
           topLeft: Radius.circular(20),
         ),
       ),
-
       child: SizedBox(
         height: 400,
         width: 380,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(30, 20, 30, 0),
+          child: Column(
+            children: [
+              Align(
+                alignment: Alignment.topLeft,
+                child: Text(
+                  '${pixelInfo.address ?? '대한민국'} ${pixelInfo.addressNumber ?? 'n'}번째 픽셀',
+                  style: TextStyle(
+                    fontSize: 22,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+              Align(
+                alignment: Alignment.topLeft,
+                child: Text(
+                  '${pixelInfo.visitCount}번 방문했어요!',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,),
+                ),
+              ),
+              SizedBox(
+                height: 10,
+              ),
+              IndividualVisitHistoryListView(visitList: pixelInfo.visitList!),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/widgets/map/individual_mode_pixel_info_bottom_sheet.dart
+++ b/lib/widgets/map/individual_mode_pixel_info_bottom_sheet.dart
@@ -5,7 +5,7 @@ import 'pixel_owner_info.dart';
 import 'visited_user_list_view.dart';
 
 class IndividualModePixelInfoBottomSheet extends StatelessWidget {
-  IndividualModePixelInfoBottomSheet({super.key, required this.pixelInfo});
+  IndividualModePixelInfoBottomSheet({super.key, required this.pixelInfo,});
 
   final IndividualModePixelInfo pixelInfo;
 
@@ -33,13 +33,14 @@ class IndividualModePixelInfoBottomSheet extends StatelessWidget {
                   style: TextStyle(
                       fontSize: 22,
                       fontWeight: FontWeight.bold,
-                      color: Colors.white,),
+                      color: Colors.white,
+                  ),
                 ),
               ),
               SizedBox(
                 height: 10,
               ),
-              PixelOwnerInfo(pixelOwnerUser: pixelInfo.pixelOwnerUser!),
+              PixelOwnerInfo(pixelOwnerUser: pixelInfo.pixelOwnerUser!,),
               const SizedBox(height: 10),
               Align(
                 alignment: Alignment.topLeft,
@@ -48,13 +49,14 @@ class IndividualModePixelInfoBottomSheet extends StatelessWidget {
                   style: TextStyle(
                       fontSize: 20,
                       fontWeight: FontWeight.bold,
-                      color: Colors.white,),
+                      color: Colors.white,
+                  ),
                 ),
               ),
               SizedBox(
                 height: 10,
               ),
-              VisitedUserListView(visitList: pixelInfo.visitList!),
+              VisitedUserListView(visitList: pixelInfo.visitList!,),
             ],
           ),
         ),

--- a/lib/widgets/map/individual_mode_pixel_info_bottom_sheet.dart
+++ b/lib/widgets/map/individual_mode_pixel_info_bottom_sheet.dart
@@ -5,7 +5,7 @@ import 'pixel_owner_info.dart';
 import 'visited_user_list_view.dart';
 
 class IndividualModePixelInfoBottomSheet extends StatelessWidget {
-  IndividualModePixelInfoBottomSheet({super.key, required this.pixelInfo});
+  IndividualModePixelInfoBottomSheet({super.key, required this.pixelInfo,});
 
   final IndividualModePixelInfo pixelInfo;
 

--- a/lib/widgets/map/individual_visit_history_list_view.dart
+++ b/lib/widgets/map/individual_visit_history_list_view.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+class IndividualVisitHistoryListView extends StatelessWidget {
+  const IndividualVisitHistoryListView({super.key, required this.visitList});
+
+  final List<DateTime> visitList;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        decoration: const BoxDecoration(
+          color: Color(0xFF8B8B8B),
+          borderRadius: BorderRadius.only(
+            topRight: Radius.circular(20),
+            topLeft: Radius.circular(20),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+          child: ListView.builder(
+            itemCount: visitList.length,
+            itemBuilder: (context, int index) {
+              return Padding(
+                padding: const EdgeInsets.all(5.0),
+                child: Text(
+                  "${visitList[index].year}년 ${visitList[index].month}월 ${visitList[index].day}일",
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+              );
+            },
+            shrinkWrap: true,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/pixel.dart
+++ b/lib/widgets/pixel.dart
@@ -4,13 +4,17 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import '../controllers/pixel_info_controller.dart';
 import '../models/individual_history_pixel.dart';
+import '../models/individual_history_pixel_info.dart';
 import '../models/individual_mode_pixel.dart';
 import '../models/individual_mode_pixel_info.dart';
+import 'map/individual_history_pixel_info_bottom_sheet.dart';
 import 'map/individual_mode_pixel_info_bottom_sheet.dart';
 
 class Pixel extends Polygon {
   static const double latPerPixel = 0.000724;
   static const double lonPerPixel = 0.000909;
+
+  static const int defaultUserId = 2;
 
   final int x;
   final int y;
@@ -84,7 +88,17 @@ class Pixel extends Polygon {
       strokeColor: Colors.blue,
       strokeWidth: 1,
       onTap: (int pixelId) async {
+        IndividualHistoryPixelInfo pixelInfo =
+        await Get.find<PixelInfoController>()
+            .getIndividualHistoryPixelInfo(pixelId, defaultUserId);
 
+        Get.bottomSheet(
+          IndividualHistoryPixelInfoBottomSheet(pixelInfo: pixelInfo),
+          clipBehavior: Clip.hardEdge,
+          backgroundColor: Colors.white,
+          enterBottomSheetDuration: Duration(milliseconds: 100),
+          exitBottomSheetDuration: Duration(milliseconds: 100),
+        );
       },
     );
   }

--- a/lib/widgets/pixel.dart
+++ b/lib/widgets/pixel.dart
@@ -83,7 +83,9 @@ class Pixel extends Polygon {
       fillColor: Colors.blue.withOpacity(0.3),
       strokeColor: Colors.blue,
       strokeWidth: 1,
-      onTap: (int pixelId) {},
+      onTap: (int pixelId) async {
+
+      },
     );
   }
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,10 +5,15 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+import 'package:ground_flip/models/individual_history_pixel_info.dart';
+import 'package:ground_flip/service/pixel_service.dart';
+Future<void> main() async {
+  await dotenv.load(fileName: ".env");
+  test('test', () async {
+    final service = PixelService();
+    IndividualHistoryPixelInfo pixel = await service.getIndividualHistoryPixelInfo(pixelId: 4049087, userId: 2);
+    print(pixel.visitList);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,15 +5,6 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:ground_flip/models/individual_history_pixel_info.dart';
-import 'package:ground_flip/service/pixel_service.dart';
-Future<void> main() async {
-  await dotenv.load(fileName: ".env");
-  test('test', () async {
-    final service = PixelService();
-    IndividualHistoryPixelInfo pixel = await service.getIndividualHistoryPixelInfo(pixelId: 4049087, userId: 2);
-    print(pixel.visitList);
-  });
-}
+
+Future<void> main() async {}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,4 +7,8 @@
 
 import 'package:flutter_test/flutter_test.dart';
 
-Future<void> main() async {}
+void main() {
+  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+  });
+}


### PR DESCRIPTION
## 작업 내용*
- 픽셀 클릭 시 개인 기록 표시 완료
- 리스트 뷰로 구현
## 고민한 내용*
- 하루에 여러 번 방문했을 때 정보가 전부 온다.
- 서버 단에서 하루에 하나 씩만 보내서 날짜 당 하나의 기록만 보여줘야 할 것 같다.
- 서버 단에서 addressNum의 자료형이 null을 허용하지 않는 int라서 addressNum이 null인 픽셀들은 현재 정상적으로 작동하지 않는다.
## 리뷰 요구사항
- 위젯 분리 잘 됐는지 봐주시면 감사하겠습니다!!
## 스크린샷
<img width="282" alt="image" src="https://github.com/SWM-M3PRO/GroundFlip-FE/assets/62949434/f1ba3899-87e7-47b6-9197-ca737ddb61f7">
