### PR TITLE
M3-151 카메라 이동이 멈췄을 때 픽셀 표시하는 기능 구현

### DIFF
--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -39,7 +39,7 @@ class MapController extends GetxController {
   void onInit() async {
     super.onInit();
     await _loadMapStyle();
-    await updateCurrentLocation();
+    await initCurrentLocation();
     _updateLatestPixel();
     await occupyPixel();
     updatePixels();
@@ -68,7 +68,7 @@ class MapController extends GetxController {
     });
   }
 
-  Future<void> updateCurrentLocation() async {
+  Future<void> initCurrentLocation() async {
     try {
       currentLocation = await location.getLocation();
       currentCameraPosition = LatLng(currentLocation.latitude!, currentLocation.longitude!);

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -33,7 +33,7 @@ class MapController extends GetxController {
   RxList<Marker> markers = <Marker>[].obs;
   RxBool isLoading = true.obs;
 
-  Timer _cameraIdleTimer = Timer(Duration(seconds: 0), () {});
+  Timer? _cameraIdleTimer;
 
   @override
   void onInit() async {
@@ -49,12 +49,12 @@ class MapController extends GetxController {
   }
 
   void onCameraIdle() {
-    _cameraIdleTimer = Timer(Duration(milliseconds: 800), updatePixels);
+    _cameraIdleTimer = Timer(Duration(milliseconds: 500), updatePixels);
   }
 
   void updateCameraPosition(CameraPosition newCameraPosition) {
     currentCameraPosition = LatLng(newCameraPosition.target.latitude, newCameraPosition.target.longitude);
-    _cameraIdleTimer.cancel();
+    _cameraIdleTimer?.cancel();
   }
 
   void _trackUserLocation() {

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -39,6 +39,8 @@ class MapScreen extends StatelessWidget {
                   ),
                   zoom: 16.0,
                 ),
+                onCameraMove: mapController.updateCameraPosition,
+                onCameraIdle: mapController.onCameraIdle,
                 onMapCreated: (GoogleMapController ctrl) {
                   mapController.completer.complete(ctrl);
                 },


### PR DESCRIPTION
## 작업 내용*
- 카메라 이동에 따라 픽셀들을 받아오게끔 수정
## 고민한 내용*
- GoogleMap의 onCameraMove와 onCameraIdle을 사용했다.
- 카메라가 멈출 때 마다 api 요청을 보내면 서버에 부담이 가기에 카메라가 멈춘 후 0.8초 뒤에 요청을 보내게 했다.
- 이를 위해 Timer를 사용했고, 카메라가 움직이면 현재 타이머를 cancel, 멈추면 start하게 구현했다.
- 또한 현재 '카메라' 위치를 저장하는 변수를 새로 만들어 onCameraMove 콜백에서 받아오는 좌표를 기반으로 카메라 위치를 추적하게했다.
- 기존에는 픽셀을 업데이트할 때 현재 사용자 위치를 기반으로 했지만, 이제는 카메라의 위치를 중심으로 하게끔 했다.
## 리뷰 요구사항
- 리뷰할 때 중점적으로 봐줬으면 하는 내용들
## 스크린샷