### PR TITLE
M3-153 마이페이지에서 유저의 기본 정보를 확인하는 기능 구현

### DIFF
--- a/lib/controllers/my_page_controller.dart
+++ b/lib/controllers/my_page_controller.dart
@@ -1,0 +1,28 @@
+import 'package:get/get.dart';
+
+import '../models/user.dart';
+import '../service/user_service.dart';
+
+class MyPageController extends GetxController {
+  final UserService userService = UserService();
+  final Rx<User> currentUserInfo = User().obs;
+
+  @override
+  Future<void> onInit() async {
+    User userInfo = await userService.getCurrentUserInfo();
+    currentUserInfo.value = userInfo;
+    super.onInit();
+  }
+
+  getProfileImageURL() {
+    return currentUserInfo.value.profileImageUrl;
+  }
+
+  getCurrentUserNickname() {
+    return currentUserInfo.value.nickname;
+  }
+
+  getCurrentUserCommunityName() {
+    return currentUserInfo.value.communityName ?? "-";
+  }
+}

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,28 @@
+class User {
+  int? userId;
+  String? nickname;
+  String? profileImageUrl;
+  int? communityId;
+  String? communityName;
+  String? birthYear;
+  String? gender;
+
+  User(
+      {this.userId,
+      this.nickname,
+      this.profileImageUrl,
+      this.communityId,
+      this.communityName,
+      this.birthYear,
+      this.gender});
+
+  User.fromJson(Map<String, dynamic> json) {
+    userId = json['userId'];
+    nickname = json['nickname'];
+    profileImageUrl = json['profileImageUrl'];
+    communityId = json['communityId'];
+    communityName = json['communityName'];
+    birthYear = json['birthYear'];
+    gender = json['gender'];
+  }
+}

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -14,7 +14,7 @@ class User {
       this.communityId,
       this.communityName,
       this.birthYear,
-      this.gender});
+      this.gender,});
 
   User.fromJson(Map<String, dynamic> json) {
     userId = json['userId'];

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
+import '../controllers/my_page_controller.dart';
 import '../controllers/navigation_controller.dart';
 import '../widgets/common/naviagtion_bar.dart';
 
@@ -11,6 +12,7 @@ class MainScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final NavigationController navigationController =
         Get.put(NavigationController());
+    Get.put(MyPageController());
 
     return Scaffold(
       appBar: PreferredSize(

--- a/lib/screens/my_page_screen.dart
+++ b/lib/screens/my_page_screen.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 
 import '../controllers/walking_controller.dart';
 import '../widgets/my_page/step_bar_chart.dart';
+import '../widgets/my_page/user_info.dart';
 
 class MyPageScreen extends StatelessWidget {
   const MyPageScreen({super.key});
@@ -11,18 +12,22 @@ class MyPageScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final WalkingController walkController = Get.put(WalkingController());
 
-    return Column(
-      children: [
-        const Text('마이페이지'),
-        Obx(() => Text(walkController.getCurrentStep())),
-        TextButton(
-          onPressed: () {
-            walkController.updateCurrentStep();
-          },
-          child: const Text('업데이트'),
-        ),
-        StepBarChart(),
-      ],
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        children: [
+          UserInfo(),
+          const Text('마이페이지'),
+          Obx(() => Text(walkController.getCurrentStep())),
+          TextButton(
+            onPressed: () {
+              walkController.updateCurrentStep();
+            },
+            child: const Text('업데이트'),
+          ),
+          StepBarChart(),
+        ],
+      ),
     );
   }
 }

--- a/lib/service/user_service.dart
+++ b/lib/service/user_service.dart
@@ -1,0 +1,21 @@
+import 'package:dio/dio.dart';
+
+import '../models/user.dart';
+import '../utils/dio_service.dart';
+
+class UserService {
+  static final UserService _instance = UserService._internal();
+  final Dio dio = DioService().getDio();
+  static const int userId = 2;
+
+  UserService._internal();
+
+  factory UserService() {
+    return _instance;
+  }
+
+  Future<User> getCurrentUserInfo() async {
+    var response = await dio.get('/users/$userId');
+    return User.fromJson(response.data['data']);
+  }
+}

--- a/lib/widgets/my_page/user_info.dart
+++ b/lib/widgets/my_page/user_info.dart
@@ -1,49 +1,64 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../controllers/my_page_controller.dart';
 
 class UserInfo extends StatelessWidget {
   const UserInfo({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final MyPageController myPageController = Get.find<MyPageController>();
     return InkWell(
       onTap: () {
         // TODO: 개인정보 수정 페이지로 넘어가게 구현
       },
       child: Ink(
-        decoration: const BoxDecoration(
-          color: Color(0xFFD9D9D9),
-          borderRadius: BorderRadius.all(Radius.circular(8)),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(10.0),
-          child: Row(
-            children: [
-              ClipOval(
-                child: Image.asset(
-                  'assets/default_profile_image.png',
-                  width: 80,
-                  height: 80,
-                ),
-              ),
-              SizedBox(
-                width: 30,
-              ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+          decoration: const BoxDecoration(
+            color: Color(0xFFD9D9D9),
+            borderRadius: BorderRadius.all(Radius.circular(8)),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(10.0),
+            child: Obx(
+              () => Row(
                 children: [
-                  Text(
-                    '민우기',
-                    style: TextStyle(fontSize: 25),
+                  ClipOval(
+                    child: myPageController.getProfileImageURL() != null
+                        ? Image.network(
+                            myPageController
+                                .getProfileImageURL()
+                                .profileImageUrl!,
+                            width: 80,
+                            height: 80,
+                            fit: BoxFit.cover,
+                          )
+                        : Image.asset(
+                            'assets/default_profile_image.png',
+                            width: 80,
+                            height: 80,
+                          ),
                   ),
-                  Text('홍익대학교', style: TextStyle(fontSize: 20)),
+                  SizedBox(
+                    width: 30,
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        myPageController.getCurrentUserNickname(),
+                        style: TextStyle(fontSize: 25),
+                      ),
+                      Text(myPageController.getCurrentUserCommunityName(),
+                          style: TextStyle(fontSize: 20)),
+                    ],
+                  ),
+                  Spacer(),
+                  Icon(Icons.arrow_forward_ios),
                 ],
               ),
-              Spacer(),
-              Icon(Icons.arrow_forward_ios),
-            ],
-          ),
-        ),
-      ),
+            ),
+          )),
     );
   }
 }

--- a/lib/widgets/my_page/user_info.dart
+++ b/lib/widgets/my_page/user_info.dart
@@ -50,7 +50,7 @@ class UserInfo extends StatelessWidget {
                         style: TextStyle(fontSize: 25),
                       ),
                       Text(myPageController.getCurrentUserCommunityName(),
-                          style: TextStyle(fontSize: 20)),
+                          style: TextStyle(fontSize: 20),),
                     ],
                   ),
                   Spacer(),
@@ -58,7 +58,7 @@ class UserInfo extends StatelessWidget {
                 ],
               ),
             ),
-          )),
+          ),),
     );
   }
 }

--- a/lib/widgets/my_page/user_info.dart
+++ b/lib/widgets/my_page/user_info.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class UserInfo extends StatelessWidget {
+  const UserInfo({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () {
+        // TODO: 개인정보 수정 페이지로 넘어가게 구현
+      },
+      child: Ink(
+        decoration: const BoxDecoration(
+          color: Color(0xFFD9D9D9),
+          borderRadius: BorderRadius.all(Radius.circular(8)),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Row(
+            children: [
+              ClipOval(
+                child: Image.asset(
+                  'assets/default_profile_image.png',
+                  width: 80,
+                  height: 80,
+                ),
+              ),
+              SizedBox(
+                width: 30,
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '민우기',
+                    style: TextStyle(fontSize: 25),
+                  ),
+                  Text('홍익대학교', style: TextStyle(fontSize: 20)),
+                ],
+              ),
+              Spacer(),
+              Icon(Icons.arrow_forward_ios),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 작업 내용*
- 마이페이지에서 유저의 기본 정보를 확인하는 기능 구현
- 유저의 데이터를 불러오는 기능 구현
## 고민한 내용*
- 지금 아직 로그인이 없어서 로그인된 유저의 값을 못 찾아오고 있어 default 값을 넣어 놨다. 
- 추후 로그인 기능 구현후 현재 로그인되어있는 사용자에 대해서는 저장을 해놓고 가져다 쓰는 방식을 사용해야될 것 같다.

- mainScreen에 MyPageController 를 넣어두었다.
  - 이렇게 하면 앱이 실행될때 내 정보를 가져오고 마이페이지를 클릭했을때 기다리지 않아도 된다.
## 리뷰 요구사항
- 리뷰할 때 중점적으로 봐줬으면 하는 내용들
## 스크린샷
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-05 at 17 25 11](https://github.com/SWM-M3PRO/GroundFlip-FE/assets/62103197/9bd5d360-f005-4179-9c65-41b103eb63aa) |
|------|

