### PR TITLE
M3-161 자동로그인 구현

### DIFF
--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -9,6 +9,7 @@ import '../enums/pixel_mode.dart';
 import '../models/individual_history_pixel.dart';
 import '../models/individual_mode_pixel.dart';
 import '../service/pixel_service.dart';
+import '../utils/user_manager.dart';
 import '../widgets/pixel.dart';
 
 class MapController extends GetxController {
@@ -18,7 +19,6 @@ class MapController extends GetxController {
   static const String userMarkerId = 'USER';
   static const double latPerPixel = 0.000724;
   static const double lonPerPixel = 0.000909;
-  static const int defaultUserId = 2;
 
   final Location location = Location();
   late final String mapStyle;
@@ -53,7 +53,10 @@ class MapController extends GetxController {
   }
 
   void updateCameraPosition(CameraPosition newCameraPosition) {
-    currentCameraPosition = LatLng(newCameraPosition.target.latitude, newCameraPosition.target.longitude);
+    currentCameraPosition = LatLng(
+      newCameraPosition.target.latitude,
+      newCameraPosition.target.longitude,
+    );
     _cameraIdleTimer?.cancel();
   }
 
@@ -71,7 +74,8 @@ class MapController extends GetxController {
   Future<void> initCurrentLocation() async {
     try {
       currentLocation = await location.getLocation();
-      currentCameraPosition = LatLng(currentLocation.latitude!, currentLocation.longitude!);
+      currentCameraPosition =
+          LatLng(currentLocation.latitude!, currentLocation.longitude!);
     } catch (e) {
       throw Error();
     } finally {
@@ -115,7 +119,7 @@ class MapController extends GetxController {
         await pixelService.getIndividualHistoryPixels(
       currentLatitude: currentCameraPosition.latitude,
       currentLongitude: currentCameraPosition.longitude,
-      userId: defaultUserId,
+      userId: UserManager().getUserId()!,
     );
 
     pixels.assignAll([
@@ -135,7 +139,7 @@ class MapController extends GetxController {
       for (var pixel in individualModePixels)
         Pixel.fromIndividualModePixel(
           pixel: pixel,
-          isMyPixel: (pixel.userId == defaultUserId),
+          isMyPixel: (pixel.userId == UserManager().getUserId()),
         ),
     ]);
   }
@@ -161,7 +165,7 @@ class MapController extends GetxController {
 
   Future<void> occupyPixel() async {
     await pixelService.occupyPixel(
-      userId: defaultUserId,
+      userId: UserManager().getUserId()!,
       currentLatitude: currentLocation.latitude!,
       currentLongitude: currentLocation.longitude!,
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:kakao_flutter_sdk/kakao_flutter_sdk_common.dart';
 
 import 'screens/login_screen.dart';
 import 'screens/main_screen.dart';
+import 'service/auth_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -14,11 +15,17 @@ Future<void> main() async {
   KakaoSdk.init(
     nativeAppKey: dotenv.env['NATIVE_APP_KEY']!,
   );
-  runApp(const MyApp());
+
+  String initialRoute = await AuthService().isLogin() ? '/main' : '/login';
+  runApp(MyApp(
+    initialRoute: initialRoute,
+  ));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({super.key, required this.initialRoute});
+
+  final String initialRoute;
 
   @override
   Widget build(BuildContext context) {
@@ -28,7 +35,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      initialRoute: '/login',
+      initialRoute: initialRoute,
       getPages: [
         GetPage(name: '/main', page: () => const MainScreen()),
         GetPage(name: '/login', page: () => const LoginScreen()),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,9 +17,11 @@ Future<void> main() async {
   );
 
   String initialRoute = await AuthService().isLogin() ? '/main' : '/login';
-  runApp(MyApp(
-    initialRoute: initialRoute,
-  ));
+  runApp(
+    MyApp(
+      initialRoute: initialRoute,
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/service/auth_service.dart
+++ b/lib/service/auth_service.dart
@@ -19,6 +19,20 @@ class AuthService {
     return _instance;
   }
 
+  Future<bool> isLogin() async {
+    String? accessToken = await secureStorage.read(
+      key: "accessToken",
+    );
+    String? refreshToken = await secureStorage.read(
+      key: "refreshToken",
+    );
+    if (accessToken == null || refreshToken == null) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
   loginWithKakao() async {
     String accessToken = await getKakaoAccessToken();
     AuthResponse authResponse = await postKakaoLogin(accessToken);

--- a/lib/service/auth_service.dart
+++ b/lib/service/auth_service.dart
@@ -99,7 +99,7 @@ class AuthService {
     }
   }
 
-  String _extractUserIdFromToken(String token) {
+  int _extractUserIdFromToken(String token) {
     final parts = token.split('.');
     if (parts.length != 3) {
       throw Exception('invalid token');
@@ -107,6 +107,6 @@ class AuthService {
     final payload =
         utf8.decode(base64Url.decode(base64Url.normalize(parts[1])));
     final payloadMap = json.decode(payload);
-    return payloadMap['userId'].toString();
+    return payloadMap['userId'];
   }
 }

--- a/lib/service/auth_service.dart
+++ b/lib/service/auth_service.dart
@@ -1,17 +1,17 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
 
 import '../models/auth_response.dart';
 import '../utils/dio_service.dart';
+import '../utils/secure_storage.dart';
 
 class AuthService {
   static final AuthService _instance = AuthService._internal();
 
   final Dio dio = DioService().getDio();
-  final FlutterSecureStorage secureStorage = const FlutterSecureStorage();
+  final SecureStorage secureStorage = SecureStorage();
 
   AuthService._internal();
 
@@ -19,13 +19,14 @@ class AuthService {
     return _instance;
   }
 
+  logout() {
+    secureStorage.deleteAccessToken();
+    secureStorage.deleteRefreshToken();
+  }
+
   Future<bool> isLogin() async {
-    String? accessToken = await secureStorage.read(
-      key: "accessToken",
-    );
-    String? refreshToken = await secureStorage.read(
-      key: "refreshToken",
-    );
+    String? accessToken = await secureStorage.readAccessToken();
+    String? refreshToken = await secureStorage.readRefreshToken();
     if (accessToken == null || refreshToken == null) {
       return false;
     } else {
@@ -41,14 +42,8 @@ class AuthService {
   }
 
   Future<void> _saveTokens(AuthResponse authResponse) async {
-    await secureStorage.write(
-      key: "accessToken",
-      value: authResponse.accessToken,
-    );
-    await secureStorage.write(
-      key: "refreshToken",
-      value: authResponse.refreshToken,
-    );
+    await secureStorage.writeAccessToken(authResponse.accessToken);
+    await secureStorage.writeRefreshToken(authResponse.refreshToken);
   }
 
   Future<AuthResponse> postKakaoLogin(String accessToken) async {

--- a/lib/service/user_service.dart
+++ b/lib/service/user_service.dart
@@ -16,13 +16,13 @@ class UserService {
   }
 
   Future<User> getCurrentUserInfo() async {
-    String? userId = UserManager().getUserId();
+    int? userId = UserManager().getUserId();
     var response = await dio.get('/users/$userId');
     return User.fromJson(response.data['data']);
   }
 
   Future<UserPixelCount> getUserPixelCount() async {
-    String? userId = UserManager().getUserId();
+    int? userId = UserManager().getUserId();
     var response = await dio.get(
       '/pixels/count',
       queryParameters: {"user-id": userId},

--- a/lib/service/user_service.dart
+++ b/lib/service/user_service.dart
@@ -3,11 +3,11 @@ import 'package:dio/dio.dart';
 import '../models/user.dart';
 import '../models/user_pixel_count.dart';
 import '../utils/dio_service.dart';
+import '../utils/user_manager.dart';
 
 class UserService {
   static final UserService _instance = UserService._internal();
   final Dio dio = DioService().getDio();
-  static const int userId = 2;
 
   UserService._internal();
 
@@ -16,11 +16,13 @@ class UserService {
   }
 
   Future<User> getCurrentUserInfo() async {
+    String? userId = UserManager().getUserId();
     var response = await dio.get('/users/$userId');
     return User.fromJson(response.data['data']);
   }
 
   Future<UserPixelCount> getUserPixelCount() async {
+    String? userId = UserManager().getUserId();
     var response = await dio.get(
       '/pixels/count',
       queryParameters: {"user-id": userId},

--- a/lib/utils/dio_service.dart
+++ b/lib/utils/dio_service.dart
@@ -1,7 +1,12 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:ground_flip/utils/secure_storage.dart';
+import 'package:get/get.dart' hide Response;
+
+import '../service/auth_service.dart';
+import 'secure_storage.dart';
 
 class DioService {
   static final DioService _dioServices = DioService._internal();
@@ -9,7 +14,6 @@ class DioService {
   final SecureStorage secureStorage = SecureStorage();
 
   factory DioService() => _dioServices;
-  Map<String, dynamic> dioInformation = {};
 
   static Dio _dio = Dio();
 
@@ -39,6 +43,10 @@ class DioService {
           DioException dioException,
           ErrorInterceptorHandler errorInterceptorHandler,
         ) {
+          if (dioException.response?.statusCode == HttpStatus.unauthorized) {
+            AuthService().logout();
+            Get.offAllNamed('/login');
+          }
           logError(dioException);
           return errorInterceptorHandler.next(dioException);
         },

--- a/lib/utils/dio_service.dart
+++ b/lib/utils/dio_service.dart
@@ -1,10 +1,12 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:ground_flip/utils/secure_storage.dart';
 
 class DioService {
   static final DioService _dioServices = DioService._internal();
   static final String baseUrl = dotenv.env['BASE_URL']!;
+  final SecureStorage secureStorage = SecureStorage();
 
   factory DioService() => _dioServices;
   Map<String, dynamic> dioInformation = {};
@@ -22,6 +24,10 @@ class DioService {
     _dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) async {
+          final accessToken = await secureStorage.readAccessToken();
+          options.headers.addAll({
+            'Authorization': 'Bearer $accessToken',
+          });
           logRequest(options);
           return handler.next(options);
         },

--- a/lib/utils/secure_storage.dart
+++ b/lib/utils/secure_storage.dart
@@ -22,12 +22,6 @@ class SecureStorage {
     );
   }
 
-  readUserId() async {
-    return await secureStorage.read(
-      key: "userId",
-    );
-  }
-
   writeAccessToken(accessToken) async {
     await secureStorage.write(
       key: "accessToken",
@@ -42,22 +36,11 @@ class SecureStorage {
     );
   }
 
-  writeUserId(userId) async {
-    await secureStorage.write(
-      key: "userId",
-      value: userId,
-    );
-  }
-
   deleteAccessToken() async {
     await secureStorage.delete(key: "accessToken");
   }
 
   deleteRefreshToken() async {
     await secureStorage.delete(key: "refreshToken");
-  }
-
-  deleteUserId() async {
-    await secureStorage.delete(key: "userId");
   }
 }

--- a/lib/utils/secure_storage.dart
+++ b/lib/utils/secure_storage.dart
@@ -22,6 +22,12 @@ class SecureStorage {
     );
   }
 
+  readUserId() async {
+    return await secureStorage.read(
+      key: "userId",
+    );
+  }
+
   writeAccessToken(accessToken) async {
     await secureStorage.write(
       key: "accessToken",
@@ -36,11 +42,22 @@ class SecureStorage {
     );
   }
 
+  writeUserId(userId) async {
+    await secureStorage.write(
+      key: "userId",
+      value: userId,
+    );
+  }
+
   deleteAccessToken() async {
     await secureStorage.delete(key: "accessToken");
   }
 
   deleteRefreshToken() async {
     await secureStorage.delete(key: "refreshToken");
+  }
+
+  deleteUserId() async {
+    await secureStorage.delete(key: "userId");
   }
 }

--- a/lib/utils/secure_storage.dart
+++ b/lib/utils/secure_storage.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class SecureStorage {
+  static final SecureStorage _instance = SecureStorage._internal();
+  final FlutterSecureStorage secureStorage = const FlutterSecureStorage();
+
+  SecureStorage._internal();
+
+  factory SecureStorage() {
+    return _instance;
+  }
+
+  readAccessToken() async {
+    return await secureStorage.read(
+      key: "accessToken",
+    );
+  }
+
+  readRefreshToken() async {
+    return await secureStorage.read(
+      key: "refreshToken",
+    );
+  }
+
+  writeAccessToken(accessToken) async {
+    await secureStorage.write(
+      key: "accessToken",
+      value: accessToken,
+    );
+  }
+
+  writeRefreshToken(refreshToken) async {
+    await secureStorage.write(
+      key: "refreshToken",
+      value: refreshToken,
+    );
+  }
+
+  deleteAccessToken() async {
+    await secureStorage.delete(key: "accessToken");
+  }
+
+  deleteRefreshToken() async {
+    await secureStorage.delete(key: "refreshToken");
+  }
+}

--- a/lib/utils/user_manager.dart
+++ b/lib/utils/user_manager.dart
@@ -1,0 +1,23 @@
+class UserManager {
+  static final UserManager _instance = UserManager._internal();
+
+  factory UserManager() {
+    return _instance;
+  }
+
+  UserManager._internal();
+
+  String? userId;
+
+  void init() {
+    userId = null;
+  }
+
+  void setUserId(String id) {
+    userId = id;
+  }
+
+  String? getUserId() {
+    return userId;
+  }
+}

--- a/lib/utils/user_manager.dart
+++ b/lib/utils/user_manager.dart
@@ -7,17 +7,17 @@ class UserManager {
 
   UserManager._internal();
 
-  String? userId;
+  int? userId;
 
   void init() {
     userId = null;
   }
 
-  void setUserId(String id) {
+  void setUserId(int id) {
     userId = id;
   }
 
-  String? getUserId() {
+  int? getUserId() {
     return userId;
   }
 }

--- a/lib/widgets/my_page/user_info.dart
+++ b/lib/widgets/my_page/user_info.dart
@@ -26,9 +26,7 @@ class UserInfo extends StatelessWidget {
                 ClipOval(
                   child: myPageController.getProfileImageURL() != null
                       ? Image.network(
-                          myPageController
-                              .getProfileImageURL()
-                              .profileImageUrl!,
+                          myPageController.getProfileImageURL(),
                           width: 80,
                           height: 80,
                           fit: BoxFit.cover,


### PR DESCRIPTION
## 작업 내용*
- 앱 실행시 로그인 유무를 판단하여 화면 라우팅 선택
- dio 요청에 jwt 값을 넣도록 구현

## 고민한 내용*
### 자동 로그인
앱이 처음 실행될 때 로그인 여부를 판단하여 로그인 화면과 메인 화면으로 이동시키는 로직이 필요했다.
#### 첫번째 방법
처음에는 
```
GetMaterialApp(
      title: 'Ground Flip',
      theme: ThemeData(
        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
        useMaterial3: true,
      ),
      initialRoute: '/login',
      getPages: [
        GetPage(name: '/main', page: () => const MainScreen()),
        GetPage(name: '/login', page: () => const LoginScreen()),
      ],
    );
```
위와 같이 로그인 페이지로 최초 진입시키고 로그인 페이지에서 로그인이 되었는지 검증하고 되었으면 main 페이지로 이동시키는 방법으로 구현했다. 이렇게 하니 로그인이 되었음에도 로그인 페이지가 1초 정도 켜지고 main 화면으로 넘어가는 문제가 있었다. 때문에 방법을 바꾸었다.

#### 두번째 방법
처음 MyApp 위젯이 빌드 될때 initialRoute 를 설정하는 방식으로 수정했다. 
```
Future<void> main() async {
  WidgetsFlutterBinding.ensureInitialized();
  await dotenv.load(fileName: ".env");
  await GetStorage.init();
  KakaoSdk.init(
    nativeAppKey: dotenv.env['NATIVE_APP_KEY']!,
  );

  String initialRoute = await AuthService().isLogin() ? '/main' : '/login';
  runApp(
    MyApp(
      initialRoute: initialRoute,
    ),
  );
}
```

main 문 에서 로그인 여부를 검색하고 첫 라우트 페이지를 설정한다.

### 현재 로그인 한 유저의 정보를 참조하기
UserManager 라는 싱글톤 클래스를 만들어서 이 클래스에서 현재 로그인된 유저의 id 를 관리한다.

따로 클래스로 분리한 이유는 추후에 유저의 개인 정보들을 캐시해두어 성능을 개선할 수도 있을 것 같았다. 유저 정보 같은 것을 매번 api 호출하기 보다 메모리에 들고 있으면 속도가 개선될 것 같았다.


### 요청에 access token 붙이기
dio 의 인터셉터를 사용하였다.
```
onRequest: (options, handler) async {
          final accessToken = await secureStorage.readAccessToken();
          options.headers.addAll({
            'Authorization': 'Bearer $accessToken',
          });
          logRequest(options);
          return handler.next(options);
        },
```
secureStorage 에서 access token 을 가져와서 헤더에 추가한다.

#### 의문점
secureStorage 는 스토리지인거 같은데 스토리지는 메모리보다 읽기속도가 느린데 매 요청마다 스토리지에서 읽어도 성능에 문제는 생기지 않을까?
## 리뷰 요구사항
- secureStorage 는 스토리지인거 같은데 스토리지는 메모리보다 읽기속도가 느린데 매 요청마다 스토리지에서 읽어도 성능에 문제는 생기지 않을까요?
## 스크린샷