### PR TITLE
M3-173 축소시 픽셀 안보이게 수정

### DIFF
--- a/assets/map_style/dark_map_style_with_landmarks.txt
+++ b/assets/map_style/dark_map_style_with_landmarks.txt
@@ -1,0 +1,188 @@
+[
+  {
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#242f3e"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#746855"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.text.stroke",
+    "stylers": [
+      {
+        "color": "#242f3e"
+      }
+    ]
+  },
+  {
+    "featureType": "administrative.land_parcel",
+    "elementType": "labels",
+    "stylers": [
+      {
+        "visibility": "off"
+      }
+    ]
+  },
+  {
+    "featureType": "administrative.locality",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#d59563"
+      }
+    ]
+  },
+  {
+    "featureType": "poi",
+    "elementType": "labels.text",
+    "stylers": [
+      {
+        "visibility": "off"
+      }
+    ]
+  },
+  {
+    "featureType": "poi",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#d59563"
+      }
+    ]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#263c3f"
+      }
+    ]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#6b9a76"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#38414e"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry.stroke",
+    "stylers": [
+      {
+        "color": "#212a37"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#9ca5b3"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#746855"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "geometry.stroke",
+    "stylers": [
+      {
+        "color": "#1f2835"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#f3d19c"
+      }
+    ]
+  },
+  {
+    "featureType": "road.local",
+    "elementType": "labels",
+    "stylers": [
+      {
+        "visibility": "off"
+      }
+    ]
+  },
+  {
+    "featureType": "transit",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#2f3948"
+      }
+    ]
+  },
+  {
+    "featureType": "transit.station",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#d59563"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#17263c"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#515c6d"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "labels.text.stroke",
+    "stylers": [
+      {
+        "color": "#17263c"
+      }
+    ]
+  }
+]

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -16,7 +16,7 @@ import '../widgets/pixel.dart';
 class MapController extends GetxController {
   final PixelService pixelService = PixelService();
 
-  static const String darkMapStylePath = 'assets/map_style/dark_map_style.txt';
+  static const String darkMapStylePath = 'assets/map_style/dark_map_style_with_landmarks.txt';
   static const String userMarkerId = 'USER';
   static const double maxZoomOutLevel = 14.0;
   static const double latPerPixel = 0.000724;


### PR DESCRIPTION
## 작업 내용*
- 일정 수준 이상 축소 시  픽셀이 안보이게끔 수정
- 지도의 범위를 동적으로 계산하여 픽셀을 가져오는 반경을 조정
- 지도 화면에 일부 랜드마크를 표시하여 편의성 개선

## 고민한 내용*
- 픽셀이 안보이게 되는 zoom level은 14.3으로 설정 (사진 참고)
- 지도의 범위를 동적으로 계산하기 위해 지도의 왼쪽 위 , 오른쪽 아래 점 사이 거리를 구함
- 이 때 haversine 공식을 사용했다.

## 리뷰 요구사항
- map controller에 점점 많은 함수가 생기는 것 같은데 다음 스프린트 때 리팩토링 해도 괜찮을 것 같습니다..!
## 스크린샷
 
<img width="318" alt="스크린샷 2024-07-11 오후 12 28 22" src="https://github.com/SWM-M3PRO/GroundFlip-FE/assets/62949434/b83dc740-6e9a-4eb5-ab64-4691ffde5e2d">
