### PR TITLE
M3-176 안드로이드 걸음수 서비스 구현

### DIFF
--- a/lib/controllers/walking_controller.dart
+++ b/lib/controllers/walking_controller.dart
@@ -12,6 +12,7 @@ class WalkingController extends GetxController {
   final RxList<int> selectedWeeklySteps = <int>[0, 0, 0, 0, 0, 0, 0].obs;
   final RxString selectedWeekInfo = "".obs;
   final RxBool isNextButtonEnabled = false.obs;
+  final RxBool isPreviousButtonEnabled = true.obs;
   late DateTime selectedWeekStartDate;
   late DateTime selectedWeekEndDate;
   late WalkingService walkingService;
@@ -19,6 +20,7 @@ class WalkingController extends GetxController {
   static double averageStride = 0.6;
   static int metersPerKilometer = 1000;
   static double averageCalorie = 0.04;
+  static DateTime checkFirstDate = DateTime.parse('2024-06-01');
 
   @override
   void onInit() {
@@ -95,6 +97,10 @@ class WalkingController extends GetxController {
     return isNextButtonEnabled.value;
   }
 
+  getIsPreviousButtonEnabled() {
+    return isPreviousButtonEnabled.value;
+  }
+
   Future<void> updateCurrentStep() async {
     currentStep.value = (await walkingService.getCurrentStep());
   }
@@ -120,6 +126,14 @@ class WalkingController extends GetxController {
     }
   }
 
+  _updatePreviousButtonStatus() {
+    if (checkFirstDate.isAfter(selectedWeekStartDate)) {
+      isPreviousButtonEnabled.value = false;
+    }else{
+      isPreviousButtonEnabled.value = true;
+    }
+  }
+
   Future<void> loadPreviousWeekSteps() async {
     selectedWeekStartDate = selectedWeekStartDate.subtract(Duration(days: 7));
     selectedWeekEndDate = selectedWeekEndDate.subtract(Duration(days: 7));
@@ -136,5 +150,6 @@ class WalkingController extends GetxController {
     _updateSelectedWeekSteps();
     _updateSelectedWeekInfo();
     _updateNextButtonStatus();
+    _updatePreviousButtonStatus();
   }
 }

--- a/lib/models/user_step_response.dart
+++ b/lib/models/user_step_response.dart
@@ -1,0 +1,17 @@
+class UserStepResponse {
+  List<int>? userId = [0,0,0,0,0,0,0];
+
+  UserStepResponse({this.userId});
+
+  List<int>? getUserId(){
+    return userId;
+  }
+
+  factory UserStepResponse.fromJson(dynamic json) {
+    if (json is List) {
+      return UserStepResponse(userId: List<int>.from(json));
+    } else {
+      throw Exception("Invalid JSON format for UserStepResponse");
+    }
+  }
+}

--- a/lib/models/user_step_response.dart
+++ b/lib/models/user_step_response.dart
@@ -1,15 +1,11 @@
 class UserStepResponse {
-  List<int>? userId = [0,0,0,0,0,0,0];
+  List<int>? steps;
 
-  UserStepResponse({this.userId});
-
-  List<int>? getUserId(){
-    return userId;
-  }
+  UserStepResponse({this.steps});
 
   factory UserStepResponse.fromJson(dynamic json) {
     if (json is List) {
-      return UserStepResponse(userId: List<int>.from(json));
+      return UserStepResponse(steps: List<int>.from(json));
     } else {
       throw Exception("Invalid JSON format for UserStepResponse");
     }

--- a/lib/service/android_walking_service.dart
+++ b/lib/service/android_walking_service.dart
@@ -39,23 +39,29 @@ class AndroidWalkingService implements WalkingService {
     DateTime endDate,
   ) async {
     int? userId = UserManager().getUserId();
-    var response = await dio.get('/steps', queryParameters: {
-      "user-id": userId,
-      "start-date": startDate,
-      "end-date": endDate
-    });
-    List<int>? result = UserStepResponse.fromJson(response.data['data']).userId ?? [];
-    print('result ${result}');
-    if(result.isEmpty){
-      return [0,0,0,0,0,0,0];
-    }else{
+    var response = await dio.get(
+      '/steps',
+      queryParameters: {
+        "user-id": userId,
+        "start-date": startDate,
+        "end-date": endDate,
+      },
+    );
+    List<int>? result =
+        UserStepResponse.fromJson(response.data['data']).userId ?? [];
+    if (result.isEmpty) {
+      return [0, 0, 0, 0, 0, 0, 0];
+    } else {
       return result;
     }
   }
 
   Future<int?> postUserStep(userId, date, steps) async {
     String format = DateFormat('yyyy-MM-dd').format(date);
-    var response = await dio.post('/steps', data: {"userId": userId, "date": format, "steps": steps});
+    var response = await dio.post(
+      '/steps',
+      data: {"userId": userId, "date": format, "steps": steps},
+    );
     return response.statusCode;
   }
 

--- a/lib/service/android_walking_service.dart
+++ b/lib/service/android_walking_service.dart
@@ -44,9 +44,13 @@ class AndroidWalkingService implements WalkingService {
       "start-date": startDate,
       "end-date": endDate
     });
-    print('steps steps ${ UserStepResponse.fromJson(response.data['data']).userId}');
-    return Future.value(
-        UserStepResponse.fromJson(response.data['data']).userId);
+    List<int>? result = UserStepResponse.fromJson(response.data['data']).userId ?? [];
+    print('result ${result}');
+    if(result.isEmpty){
+      return [0,0,0,0,0,0,0];
+    }else{
+      return result;
+    }
   }
 
   Future<int?> postUserStep(userId, date, steps) async {

--- a/lib/service/android_walking_service.dart
+++ b/lib/service/android_walking_service.dart
@@ -48,7 +48,7 @@ class AndroidWalkingService implements WalkingService {
       },
     );
     List<int>? result =
-        UserStepResponse.fromJson(response.data['data']).userId ?? [];
+        UserStepResponse.fromJson(response.data['data']).steps ?? [];
     if (result.isEmpty) {
       return [0, 0, 0, 0, 0, 0, 0];
     } else {

--- a/lib/service/android_walking_service.dart
+++ b/lib/service/android_walking_service.dart
@@ -56,13 +56,12 @@ class AndroidWalkingService implements WalkingService {
     }
   }
 
-  Future<int?> postUserStep(userId, date, steps) async {
-    String format = DateFormat('yyyy-MM-dd').format(date);
-    var response = await dio.post(
+  Future<void> postUserStep(userId, date, steps) async {
+    String formattedDate = DateFormat('yyyy-MM-dd').format(date);
+    await dio.post(
       '/steps',
-      data: {"userId": userId, "date": format, "steps": steps},
+      data: {"userId": userId, "date": formattedDate, "steps": steps},
     );
-    return response.statusCode;
   }
 
   Future<void> _initForegroundWalkingTask() async {

--- a/lib/service/auth_service.dart
+++ b/lib/service/auth_service.dart
@@ -44,7 +44,7 @@ class AuthService {
     if (accessToken == null || refreshToken == null) {
       return false;
     } else {
-      UserManager().setUserId(_extractUserIdFromToken(accessToken));
+      UserManager().setUserId(extractUserIdFromToken(accessToken));
       return true;
     }
   }
@@ -59,7 +59,7 @@ class AuthService {
   Future<void> _saveTokens(LoginResponse authResponse) async {
     await secureStorage.writeAccessToken(authResponse.accessToken);
     await secureStorage.writeRefreshToken(authResponse.refreshToken);
-    UserManager().setUserId(_extractUserIdFromToken(authResponse.accessToken!));
+    UserManager().setUserId(extractUserIdFromToken(authResponse.accessToken!));
   }
 
   Future<LoginResponse> postKakaoLogin(String accessToken) async {
@@ -109,7 +109,7 @@ class AuthService {
     }
   }
 
-  int _extractUserIdFromToken(String token) {
+  int extractUserIdFromToken(String token) {
     final parts = token.split('.');
     if (parts.length != 3) {
       throw Exception('invalid token');

--- a/lib/utils/android_notification.dart
+++ b/lib/utils/android_notification.dart
@@ -98,7 +98,7 @@ class AndroidWalkingHandler extends TaskHandler {
     String token = await secureStorage.readAccessToken();
     int userId = authService.extractUserIdFromToken(token);
     DateTime previousDay = DateTime.now().subtract(Duration(days: 1));
-    androidWalkingService.postUserStep(userId, previousDay, currentSteps);
+    await androidWalkingService.postUserStep(userId, previousDay, currentSteps);
 
     currentSteps = 0;
     _localStorage.write(todayStepKey, 0);

--- a/lib/utils/android_notification.dart
+++ b/lib/utils/android_notification.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:isolate';
-import 'dart:math';
 
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';

--- a/lib/utils/android_notification.dart
+++ b/lib/utils/android_notification.dart
@@ -74,9 +74,9 @@ class AndroidWalkingHandler extends TaskHandler {
     _stepCountStream = Pedometer.stepCountStream.asBroadcastStream();
     _stepCountStream.listen(updateStep).onError(onStepCountError);
     _initializeMidnightReset();
-    Timer.periodic(Duration(seconds: 5), (t) {
-      _resetStepsAtMidnight();
-    });
+    // Timer.periodic(Duration(seconds: 5), (t) {
+    //   _resetStepsAtMidnight();
+    // });
   }
 
   void onStepCountError(error) {

--- a/lib/utils/android_notification.dart
+++ b/lib/utils/android_notification.dart
@@ -74,9 +74,6 @@ class AndroidWalkingHandler extends TaskHandler {
     _stepCountStream = Pedometer.stepCountStream.asBroadcastStream();
     _stepCountStream.listen(updateStep).onError(onStepCountError);
     _initializeMidnightReset();
-    // Timer.periodic(Duration(seconds: 5), (t) {
-    //   _resetStepsAtMidnight();
-    // });
   }
 
   void onStepCountError(error) {

--- a/lib/utils/android_notification.dart
+++ b/lib/utils/android_notification.dart
@@ -85,7 +85,8 @@ class AndroidWalkingHandler extends TaskHandler {
 
   void _initializeMidnightReset() {
     DateTime now = DateTime.now();
-    DateTime midnight = DateTime(now.year, now.month, now.day + 1);
+    DateTime midnight =
+        DateTime(now.year, now.month, now.day + 1, now.minute + 1);
     Duration timeUntilMidnight = midnight.difference(now);
     _midnightTimer?.cancel();
     _midnightTimer = Timer(timeUntilMidnight, () {
@@ -97,12 +98,12 @@ class AndroidWalkingHandler extends TaskHandler {
     });
   }
 
-  void _resetStepsAtMidnight() {
-    final String token = secureStorage.readAccessToken();
+  void _resetStepsAtMidnight() async {
+    String token = await secureStorage.readAccessToken();
     int userId = authService.extractUserIdFromToken(token);
-    print('reset reset');
-    androidWalkingService.postUserStep(userId, DateTime.now(), currentSteps);
-    // TODO : 서버에 걸음수 저장하는 로직 추가
+    DateTime previousDay = DateTime.now().subtract(Duration(days: 1));
+    androidWalkingService.postUserStep(userId, previousDay, currentSteps);
+
     currentSteps = 0;
     _localStorage.write(todayStepKey, 0);
 

--- a/lib/widgets/my_page/step_bar_chart.dart
+++ b/lib/widgets/my_page/step_bar_chart.dart
@@ -18,11 +18,15 @@ class StepBarChart extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              IconButton(
-                onPressed: () async {
-                  await walkController.loadPreviousWeekSteps();
-                },
-                icon: Icon(Icons.arrow_back_ios_new_outlined),
+              Obx(
+                () => IconButton(
+                  onPressed: walkController.getIsPreviousButtonEnabled()
+                      ? () {
+                          walkController.loadPreviousWeekSteps();
+                        }
+                      : null,
+                  icon: Icon(Icons.arrow_back_ios_new_outlined),
+                ),
               ),
               Obx(() => Text(walkController.getSelectedWeekInfo())),
               Obx(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -377,7 +377,7 @@ packages:
     source: hosted
     version: "4.0.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   flutter_foreground_task: ^6.5.0
   kakao_flutter_sdk: ^1.9.3
   flutter_secure_storage: ^9.2.2
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 작업 내용*
- db에서 걸음수 데이터 get
- 안드로이드 걸음수 그래프에 해당 사항 적용
- 24년 6월1일 주차 이전으로 걸음수 그래프를 이동할 수 없도록
- 매시 정각 오늘의 걸음수를 post
- 가입 날짜 이전으로 넘어가서 빈 데이터가 넘어오면 전부 0으로 처리한다

## 고민한 내용*
- 타이머로 post 테스트는 완료했지만, 정각에 제대로된 내용이 가는지 확인이 한번 더 필요할듯
- 현재 해당 날짜에 데이터가 없으면 그래프가 7개가 전부 만들어지지 않는 이슈 존재
- 백에서 로직의 수정이 필요할 듯
- 기술적 고민
- db에 데이터가 존재하지 않을때의 해결방안이 필요할듯
## 리뷰 요구사항
- 함수명, 변수명, 구현 로직
## 스크린샷
| ![image](https://github.com/user-attachments/assets/79af8b26-a1aa-4c1b-b43f-f3a4b33f79c6)
|
