### PR TITLE
M3-170 회원정보 등록 UI, 서비스

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string></string>
+    <key>NSCameraUsageDescription</key>
+    <string></string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string></string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -36,7 +36,7 @@ class SignUpController extends GetxController {
     }
   }
 
-  void updateSelectedValue(int index) {
+  void updateSelectedGender(int index) {
     if (index == 0) {
       toggleSelection.assignAll([true, false]);
       gender.value = 'MALE';

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -1,7 +1,4 @@
 import 'package:get/get.dart';
-import 'package:get/get_rx/get_rx.dart';
-import 'package:get/get_rx/src/rx_types/rx_types.dart';
-import 'package:get/state_manager.dart';
 import 'package:image_picker/image_picker.dart';
 
 import '../service/user_service.dart';
@@ -28,8 +25,13 @@ class SignUpController extends GetxController {
   }
 
   Future getImage() async {
-    XFile? pickedImage  = await picker.pickImage(source: ImageSource.gallery);
-    if(pickedImage != null) {
+    XFile? pickedImage = await picker.pickImage(
+      source: ImageSource.gallery,
+      maxWidth: 75,
+      maxHeight: 75,
+      imageQuality: 30,
+    );
+    if (pickedImage != null) {
       profileImage.value = pickedImage;
     }
   }
@@ -58,7 +60,14 @@ class SignUpController extends GetxController {
   }
 
   void completeRegistration() async {
-    await userService.putUserInfo(gender.value, birthYear.value, nickname.value);
-    Get.offAllNamed('/main');
+    int? statusCode = await userService.putUserInfo(
+      gender: gender.value,
+      birthYear: birthYear.value,
+      nickname: nickname.value,
+      profileImagePath: profileImage.value?.path,
+    );
+    if (statusCode == 200) {
+      Get.offAllNamed('/main');
+    }
   }
 }

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -2,11 +2,15 @@ import 'package:get/get.dart';
 import 'package:get/get_rx/get_rx.dart';
 import 'package:get/get_rx/src/rx_types/rx_types.dart';
 import 'package:get/state_manager.dart';
+import 'package:image_picker/image_picker.dart';
 
 import '../service/user_service.dart';
 
 class SignUpController extends GetxController {
   final UserService userService = UserService();
+  final ImagePicker picker = ImagePicker();
+
+  var profileImage = Rxn<XFile>();
 
   late RxList<bool> toggleSelection;
   bool isMale = true;
@@ -21,6 +25,13 @@ class SignUpController extends GetxController {
   void onInit() {
     toggleSelection = [isMale, isFemale].obs;
     super.onInit();
+  }
+
+  Future getImage() async {
+    XFile? pickedImage  = await picker.pickImage(source: ImageSource.gallery);
+    if(pickedImage != null) {
+      profileImage.value = pickedImage;
+    }
   }
 
   void updateSelectedValue(int index) {

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -25,14 +25,14 @@ class SignUpController extends GetxController {
   }
 
   Future getImage() async {
-    XFile? pickedImage = await picker.pickImage(
+    XFile? selectedImage = await picker.pickImage(
       source: ImageSource.gallery,
       maxWidth: 75,
       maxHeight: 75,
       imageQuality: 30,
     );
-    if (pickedImage != null) {
-      profileImage.value = pickedImage;
+    if (selectedImage != null) {
+      profileImage.value = selectedImage;
     }
   }
 

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -46,7 +46,7 @@ class SignUpController extends GetxController {
     }
   }
 
-  void compltetRegistration() async {
+  void completeRegistration() async {
     await userService.putUserInfo(gender.value, birthYear.value, nickname.value);
     Get.offAllNamed('/main');
   }

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -1,0 +1,53 @@
+import 'package:get/get.dart';
+import 'package:get/get_rx/get_rx.dart';
+import 'package:get/get_rx/src/rx_types/rx_types.dart';
+import 'package:get/state_manager.dart';
+import 'package:get_storage/get_storage.dart';
+
+class SignUpController extends GetxController {
+  late RxList<bool> toggleSelection;
+  bool isMale = true;
+  bool isFemale = false;
+
+  RxString nickname = ''.obs;
+  RxInt birthYear = 2000.obs;
+  RxString gender = 'MALE'.obs;
+  RxBool isNicknameTyped = false.obs;
+
+  @override
+  void onInit() {
+    toggleSelection = [isMale, isFemale].obs;
+    super.onInit();
+  }
+
+  void updateSelectedValue(int index) {
+    if (index == 0) {
+      toggleSelection.assignAll([true, false]);
+      gender.value = 'MALE';
+    } else {
+      toggleSelection.assignAll([false, true]);
+      gender.value = 'FEMALE';
+    }
+  }
+
+  void updateBirthYear(int inputBirthYear) {
+    birthYear.value = inputBirthYear;
+  }
+
+  void updateNickname(String inputString) {
+    nickname.value = inputString;
+    if (inputString == '') {
+      isNicknameTyped.value = false;
+    } else {
+      isNicknameTyped.value = true;
+    }
+  }
+
+  void compltetRegistration() {
+    print('--------------------');
+    print(gender.value);
+    print(birthYear.value);
+    print(nickname.value);
+    print('--------------------');
+  }
+}

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -2,9 +2,12 @@ import 'package:get/get.dart';
 import 'package:get/get_rx/get_rx.dart';
 import 'package:get/get_rx/src/rx_types/rx_types.dart';
 import 'package:get/state_manager.dart';
-import 'package:get_storage/get_storage.dart';
+
+import '../service/user_service.dart';
 
 class SignUpController extends GetxController {
+  final UserService userService = UserService();
+
   late RxList<bool> toggleSelection;
   bool isMale = true;
   bool isFemale = false;
@@ -43,11 +46,8 @@ class SignUpController extends GetxController {
     }
   }
 
-  void compltetRegistration() {
-    print('--------------------');
-    print(gender.value);
-    print(birthYear.value);
-    print(nickname.value);
-    print('--------------------');
+  void compltetRegistration() async {
+    await userService.putUserInfo(gender.value, birthYear.value, nickname.value);
+    Get.offAllNamed('/main');
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,8 +6,8 @@ import 'package:kakao_flutter_sdk/kakao_flutter_sdk_common.dart';
 
 import 'screens/login_screen.dart';
 import 'screens/main_screen.dart';
-import 'screens/sign_up_screen.dart';
 import 'screens/setting_screen.dart';
+import 'screens/sign_up_screen.dart';
 import 'service/auth_service.dart';
 
 Future<void> main() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:kakao_flutter_sdk/kakao_flutter_sdk_common.dart';
 
 import 'screens/login_screen.dart';
 import 'screens/main_screen.dart';
+import 'screens/sign_up_screen.dart';
 import 'screens/setting_screen.dart';
 import 'service/auth_service.dart';
 
@@ -43,6 +44,7 @@ class MyApp extends StatelessWidget {
         GetPage(name: '/main', page: () => const MainScreen()),
         GetPage(name: '/login', page: () => const LoginScreen()),
         GetPage(name: '/setting', page: () => const SettingScreen()),
+        GetPage(name: '/signup', page: () => const SignUpScreen()),
       ],
     );
   }

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -1,0 +1,175 @@
+import 'package:dropdown_button2/dropdown_button2.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controllers/sign_up_controller.dart';
+
+class SignUpScreen extends StatelessWidget {
+  const SignUpScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final SignUpController controller = Get.put(SignUpController());
+
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      appBar: AppBar(
+        title: Text('프로필 입력'),
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back),
+          onPressed: () {
+            Get.previousRoute;
+          },
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            CircleAvatar(
+              radius: 80.0,
+              backgroundImage:
+                  AssetImage('assets/images/default_profile_image.png'),
+              child: Align(
+                alignment: Alignment.bottomRight,
+                child: Icon(Icons.photo_camera_back),
+              ),
+            ),
+            SizedBox(height: 48.0),
+            Column(
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Row(
+                    children: [
+                      Text(
+                        '닉네임',
+                        style: TextStyle(fontSize: 16.0),
+                      ),
+                      SizedBox(
+                        width: 5.0,
+                      ),
+                      Text(
+                        '영어,한글,숫자 조합으로 3자 이상 10자 이내',
+                        style: TextStyle(
+                          fontSize: 10.0,
+                          color: Colors.grey,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                SizedBox(height: 4.0),
+                Container(
+                  color: Color(0xffD9D9D9),
+                  child: TextField(
+                    decoration: InputDecoration(
+                      border: InputBorder.none,
+                      contentPadding:
+                          EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
+                    ),
+                    style: TextStyle(fontSize: 16.0),
+                    onChanged: controller.updateNickname,
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 16),
+            Column(
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '출생년도',
+                    style: TextStyle(fontSize: 16.0),
+                  ),
+                ),
+                SizedBox(height: 4.0),
+                DropdownButtonHideUnderline(
+                  child: DropdownButton2<int>(
+                    value: controller.birthYear.value,
+                    alignment: Alignment.center,
+                    isExpanded: true,
+                    onChanged: (birthYear) =>
+                        controller.updateBirthYear(birthYear!),
+                    items: List.generate(
+                      2024 - 1900 + 1,
+                      (index) {
+                        int year = 1900 + index;
+                        return DropdownMenuItem(
+                          value: year,
+                          child: Text(
+                            year.toString(),
+                            style: const TextStyle(
+                              fontSize: 14.0,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                    buttonStyleData: ButtonStyleData(
+                      decoration: BoxDecoration(
+                        color: Color(0xffD9D9D9),
+                      ),
+                    ),
+                    dropdownStyleData: DropdownStyleData(
+                      maxHeight: 200,
+                      decoration: BoxDecoration(
+                        color: Color(0xffD9D9D9),
+                      ),
+                    ),
+                    menuItemStyleData: const MenuItemStyleData(),
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 16),
+            Column(
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '성별',
+                    style: TextStyle(fontSize: 16.0),
+                  ),
+                ),
+                SizedBox(height: 4.0),
+                Obx(
+                  () => ToggleButtons(
+                    constraints: BoxConstraints.expand(
+                        width:
+                            (MediaQuery.of(context).size.width - 100) / 2), //
+                    isSelected: controller.toggleSelection,
+                    onPressed: controller.updateSelectedValue,
+                    children: [
+                      Text(
+                        '남성',
+                        style: TextStyle(fontSize: 16.0),
+                      ),
+                      Text(
+                        '여성',
+                        style: TextStyle(fontSize: 16.0),
+                      ),
+                    ],
+                  ),
+                ),
+                SizedBox(height: 16),
+                Obx(
+                  () => ElevatedButton(
+                    onPressed: controller.isNicknameTyped.value ? controller.compltetRegistration : null,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.purpleAccent,
+                      disabledBackgroundColor: Colors.grey,
+                    ),
+                    // onPressed: controller.isFormValid.value.
+                    child: Text('완료'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -12,8 +12,8 @@ class SignUpScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final SignUpController controller = Get.put(SignUpController());
-    final int lowBoundYear = 1900;
-    final int upperBoundYear = 2024;
+    const int lowBoundYear = 1900;
+    const int upperBoundYear = 2024;
 
     return Scaffold(
       resizeToAvoidBottomInset: false,

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -12,6 +12,8 @@ class SignUpScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final SignUpController controller = Get.put(SignUpController());
+    final int lowBoundYear = 1900;
+    final int upperBoundYear = 2024;
 
     return Scaffold(
       resizeToAvoidBottomInset: false,
@@ -110,7 +112,7 @@ class SignUpScreen extends StatelessWidget {
                     onChanged: (birthYear) =>
                         controller.updateBirthYear(birthYear!),
                     items: List.generate(
-                      2024 - 1900 + 1,
+                      upperBoundYear - lowBoundYear + 1,
                       (index) {
                         int year = 1900 + index;
                         return DropdownMenuItem(

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -155,7 +155,7 @@ class SignUpScreen extends StatelessWidget {
                   () => ToggleButtons(
                     constraints: BoxConstraints.expand(
                         width:
-                            (MediaQuery.of(context).size.width - 100) / 2), //
+                            (MediaQuery.of(context).size.width - 100) / 2,), //
                     isSelected: controller.toggleSelection,
                     onPressed: controller.updateSelectedGender,
                     children: [
@@ -170,21 +170,21 @@ class SignUpScreen extends StatelessWidget {
                     ],
                   ),
                 ),
-                SizedBox(height: 16),
-                Obx(
-                  () => ElevatedButton(
-                    onPressed: controller.isNicknameTyped.value
-                        ? controller.completeRegistration
-                        : null,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.purpleAccent,
-                      disabledBackgroundColor: Colors.grey,
-                    ),
-                    // onPressed: controller.isFormValid.value.
-                    child: Text('완료'),
-                  ),
-                ),
               ],
+            ),
+            SizedBox(height: 16),
+            Obx(
+              () => ElevatedButton(
+                onPressed: controller.isNicknameTyped.value
+                    ? controller.completeRegistration
+                    : null,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.purpleAccent,
+                  disabledBackgroundColor: Colors.grey,
+                ),
+                // onPressed: controller.isFormValid.value.
+                child: Text('완료'),
+              ),
             ),
           ],
         ),

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -157,7 +157,7 @@ class SignUpScreen extends StatelessWidget {
                         width:
                             (MediaQuery.of(context).size.width - 100) / 2), //
                     isSelected: controller.toggleSelection,
-                    onPressed: controller.updateSelectedValue,
+                    onPressed: controller.updateSelectedGender,
                     children: [
                       Text(
                         '남성',

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -182,7 +182,6 @@ class SignUpScreen extends StatelessWidget {
                   backgroundColor: Colors.purpleAccent,
                   disabledBackgroundColor: Colors.grey,
                 ),
-                // onPressed: controller.isFormValid.value.
                 child: Text('완료'),
               ),
             ),

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -32,7 +32,7 @@ class SignUpScreen extends StatelessWidget {
                   AssetImage('assets/images/default_profile_image.png'),
               child: Align(
                 alignment: Alignment.bottomRight,
-                child: Icon(Icons.photo_camera_back),
+                child: IconButton(onPressed: () {  }, icon: Icon(Icons.add)),
               ),
             ),
             SizedBox(height: 48.0),
@@ -156,7 +156,7 @@ class SignUpScreen extends StatelessWidget {
                 SizedBox(height: 16),
                 Obx(
                   () => ElevatedButton(
-                    onPressed: controller.isNicknameTyped.value ? controller.compltetRegistration : null,
+                    onPressed: controller.isNicknameTyped.value ? controller.completeRegistration : null,
                     style: ElevatedButton.styleFrom(
                       backgroundColor: Colors.purpleAccent,
                       disabledBackgroundColor: Colors.grey,

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -26,13 +28,28 @@ class SignUpScreen extends StatelessWidget {
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: [
-            CircleAvatar(
-              radius: 80.0,
-              backgroundImage:
-                  AssetImage('assets/images/default_profile_image.png'),
-              child: Align(
-                alignment: Alignment.bottomRight,
-                child: IconButton(onPressed: () {  }, icon: Icon(Icons.add)),
+            Obx(
+              () => CircleAvatar(
+                radius: 80.0,
+                backgroundImage: controller.profileImage.value != null
+                    ? FileImage(File(controller.profileImage.value!.path))
+                        as ImageProvider
+                    : AssetImage('assets/images/default_profile_image.png')
+                        as ImageProvider,
+                child: Align(
+                  alignment: Alignment.bottomRight,
+                  child: IconButton(
+                    style: ButtonStyle(
+                      backgroundColor:
+                          WidgetStatePropertyAll(Color(0xffD9D9D9)),
+                    ),
+                    onPressed: controller.getImage,
+                    icon: Icon(
+                      Icons.add,
+                      color: Colors.black,
+                    ),
+                  ),
+                ),
               ),
             ),
             SizedBox(height: 48.0),
@@ -156,7 +173,9 @@ class SignUpScreen extends StatelessWidget {
                 SizedBox(height: 16),
                 Obx(
                   () => ElevatedButton(
-                    onPressed: controller.isNicknameTyped.value ? controller.completeRegistration : null,
+                    onPressed: controller.isNicknameTyped.value
+                        ? controller.completeRegistration
+                        : null,
                     style: ElevatedButton.styleFrom(
                       backgroundColor: Colors.purpleAccent,
                       disabledBackgroundColor: Colors.grey,

--- a/lib/service/auth_service.dart
+++ b/lib/service/auth_service.dart
@@ -35,7 +35,15 @@ class AuthService {
   }
 
   postLogout() async {
-    await dio.post('/auth/logout');
+    String? accessToken = await secureStorage.readAccessToken();
+    String? refreshToken = await secureStorage.readRefreshToken();
+    await dio.post(
+      '/auth/logout',
+      data: {
+        "accessToken": accessToken,
+        "refreshToken": refreshToken,
+      },
+    );
   }
 
   Future<bool> isLogin() async {

--- a/lib/service/user_service.dart
+++ b/lib/service/user_service.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 
 import 'package:dio/dio.dart';
 

--- a/lib/service/user_service.dart
+++ b/lib/service/user_service.dart
@@ -1,5 +1,6 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
-import 'package:get/get.dart';
 
 import '../models/user.dart';
 import '../models/user_pixel_count.dart';
@@ -31,20 +32,30 @@ class UserService {
     return UserPixelCount.fromJson(response.data['data']);
   }
 
-  Future<void> putUserInfo(
-      String gender, int birthYear, String nickname) async {
+  Future<int?> putUserInfo({
+    required String gender,
+    required int birthYear,
+    required String nickname,
+    String? profileImagePath,
+  }) async {
     int? userId = UserManager().getUserId();
-    var response = await dio.put(
-      '/users/$userId',
-      data: {
+    var formData = FormData.fromMap(
+      {
         'gender': gender,
         'birthYear': birthYear,
         'nickname': nickname,
       },
     );
-
-    if (response.statusCode == 400) {
-      throw Error();
+    if (profileImagePath != null) {
+      formData.fields.add(MapEntry('profileImage', profileImagePath));
     }
+    print(formData.fields.toString());
+    var response = await dio.put(
+      '/users/$userId',
+      data: formData,
+      options: Options(contentType: 'multipart/form-data'),
+    );
+
+    return response.statusCode;
   }
 }

--- a/lib/service/user_service.dart
+++ b/lib/service/user_service.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:get/get.dart';
 
 import '../models/user.dart';
 import '../models/user_pixel_count.dart';
@@ -28,5 +29,22 @@ class UserService {
       queryParameters: {"user-id": userId},
     );
     return UserPixelCount.fromJson(response.data['data']);
+  }
+
+  Future<void> putUserInfo(
+      String gender, int birthYear, String nickname) async {
+    int? userId = UserManager().getUserId();
+    var response = await dio.put(
+      '/users/$userId',
+      data: {
+        'gender': gender,
+        'birthYear': birthYear,
+        'nickname': nickname,
+      },
+    );
+
+    if (response.statusCode == 400) {
+      throw Error();
+    }
   }
 }

--- a/lib/service/user_service.dart
+++ b/lib/service/user_service.dart
@@ -46,10 +46,11 @@ class UserService {
         'nickname': nickname,
       },
     );
+
     if (profileImagePath != null) {
       formData.fields.add(MapEntry('profileImage', profileImagePath));
     }
-    print(formData.fields.toString());
+
     var response = await dio.put(
       '/users/$userId',
       data: formData,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "55d7b444feb71301ef6b8838dbc1ae02e63dd48c8773f3810ff53bb1e2945b32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+1"
   crypto:
     dependency: transitive
     description:
@@ -177,6 +185,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "045d372bf19b02aeb69cacf8b4009555fb5f6f0b7ad8016e5f46dd1387ddd492"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.2+1"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: f42eacb83b318e183b1ae24eead1373ab1334084404c8c16e0354f9a3e55d385
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: d3547240c20cabf205c7c7f01a50ecdbc413755814d6677f3cb366f04abcead0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+1"
   fl_chart:
     dependency: "direct main"
     description:
@@ -368,6 +408,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.4"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   http_parser:
     dependency: transitive
     description:
@@ -376,6 +424,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: ff39a10ab4f48f4ac70776d0494a97bf073cd2570892cd46bc8a5cac162c25db
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+4"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "5d6eb13048cd47b60dbf1a5495424dea226c5faf3950e20bf8120a58efb5b5f3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.4"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "6703696ad49f5c3c8356d576d7ace84d1faf459afb07accbb0fae780753ff447"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "3f5ad1e8112a9a6111c46d0b57a7be2286a9a07fc6e1976fdf5be2bd31d4ff62"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "9ec26d410ff46f483c5519c29c02ef0e02e13a543f882b152d4bfd2f06802f80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.0"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   intl:
     dependency: transitive
     description:
@@ -560,6 +672,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   flutter_foreground_task: ^6.5.0
   kakao_flutter_sdk: ^1.9.3
   flutter_secure_storage: ^9.2.2
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 작업 내용*
- 회원가입 시 유저 정보를 입력하는 화면, 서비스 구현

## 고민한 내용*
- 위젯을 분리하여 회원정보 수정 화면과 위젯을 공유하고 싶었으나, 위젯을 분리 시 GetX Controller의 함수를 주입받아 활용할 수 없었음. 따라서 현재는 별도의 분리 없이 사용함.
- 회원 등록 서비스 함수가 상태코드를 리턴하게끔해 200을 반환받았을 때에만 main 페이지로 넘어가게 함.
- 또한 완료 버튼은 모든 필드가 활성화 된 상태에서만 유효하게끔(보라색으로 변하게끔) 설정했다.
- 이미지 등록은 image_picker 라이브러리를 사용함. ios는 별도의 권한이 필요해 info_plist 파일을 수정

## 스크린샷
<img width="335" alt="image" src="https://github.com/user-attachments/assets/0a770b55-9c98-4f18-8677-91100cba2694">
