### PR TITLE
M3-188 권한 거부 시 앱 종료하게끔 수정

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -18,6 +18,8 @@ PODS:
     - GoogleMaps/Base
   - health (1.0.4):
     - Flutter
+  - image_picker_ios (0.0.1):
+    - Flutter
   - kakao_flutter_sdk_common (1.9.3):
     - Flutter
   - location (0.0.1):
@@ -43,6 +45,7 @@ DEPENDENCIES:
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
   - health (from `.symlinks/plugins/health/ios`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - kakao_flutter_sdk_common (from `.symlinks/plugins/kakao_flutter_sdk_common/ios`)
   - location (from `.symlinks/plugins/location/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
@@ -70,6 +73,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/google_maps_flutter_ios/ios"
   health:
     :path: ".symlinks/plugins/health/ios"
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
   kakao_flutter_sdk_common:
     :path: ".symlinks/plugins/kakao_flutter_sdk_common/ios"
   location:
@@ -94,6 +99,7 @@ SPEC CHECKSUMS:
   google_maps_flutter_ios: 5bc2be60ad012e79b182ce0fb0ef5030a50fb03e
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   health: 5a380c0f6c4f619535845992993964293962e99e
+  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   kakao_flutter_sdk_common: 80c3308f209f3d6cc74e338ffea3a51d17501d77
   location: d5cf8598915965547c3f36761ae9cc4f4e87d22e
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46

--- a/lib/controllers/permission_controller.dart
+++ b/lib/controllers/permission_controller.dart
@@ -1,28 +1,58 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
-import 'package:location/location.dart';
+
+import 'package:permission_handler/permission_handler.dart';
 
 class PermissionController extends GetxController {
-  var gpsEnabled = false.obs;
-  Location location = Location();
-  PermissionStatus gpsPermissionStatus = PermissionStatus.denied;
 
   @override
-  void onInit() {
+  void onInit() async {
     super.onInit();
-    checkPermissions();
+    await checkPermissions();
   }
 
   Future<void> checkPermissions() async {
-    gpsPermissionStatus = await location.hasPermission();
-    if (gpsPermissionStatus == PermissionStatus.denied) {
-      await requestGpsPermission();
+    if (Platform.isAndroid) {
+      await requestAndroidPermissions();
+    } else if (Platform.isIOS) {
+      await requestIosPermissions();
     }
   }
 
-  Future<void> requestGpsPermission() async {
-    gpsPermissionStatus = await location.requestPermission();
-    if(gpsPermissionStatus == PermissionStatus.denied) {
-      return;
+  void exitApp() {
+    if (Platform.isIOS) {
+      exit(0);
+    } else {
+      SystemNavigator.pop();
     }
+  }
+
+  Future<void> requestAndroidPermissions() async {
+    Map<Permission, PermissionStatus> androidPermissionStatus = await [
+      Permission.location,
+      Permission.activityRecognition,
+      Permission.notification,
+    ].request();
+
+    androidPermissionStatus.values.forEach((element) async {
+      if (element.isDenied || element.isPermanentlyDenied) {
+        exitApp();
+      }
+    });
+  }
+
+  Future<void> requestIosPermissions() async {
+    Map<Permission, PermissionStatus> iosPermissionStatus = await [
+      Permission.location,
+      Permission.sensors,
+    ].request();
+
+    iosPermissionStatus.values.forEach((element) async {
+      if (element.isDenied || element.isPermanentlyDenied) {
+        exitApp();
+      }
+    });
   }
 }

--- a/lib/controllers/permission_controller.dart
+++ b/lib/controllers/permission_controller.dart
@@ -6,7 +6,6 @@ import 'package:get/get.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 class PermissionController extends GetxController {
-
   @override
   void onInit() async {
     super.onInit();
@@ -36,11 +35,11 @@ class PermissionController extends GetxController {
       Permission.notification,
     ].request();
 
-    androidPermissionStatus.values.forEach((element) async {
-      if (element.isDenied || element.isPermanentlyDenied) {
+    for (PermissionStatus status in androidPermissionStatus.values) {
+      if (status.isDenied || status.isPermanentlyDenied) {
         exitApp();
       }
-    });
+    }
   }
 
   Future<void> requestIosPermissions() async {
@@ -49,10 +48,10 @@ class PermissionController extends GetxController {
       Permission.sensors,
     ].request();
 
-    iosPermissionStatus.values.forEach((element) async {
-      if (element.isDenied || element.isPermanentlyDenied) {
+    for (PermissionStatus status in iosPermissionStatus.values) {
+      if (status.isDenied || status.isPermanentlyDenied) {
         exitApp();
       }
-    });
+    }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 import 'package:get_storage/get_storage.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_common.dart';
 
+import 'controllers/permission_controller.dart';
 import 'screens/login_screen.dart';
 import 'screens/main_screen.dart';
 import 'screens/setting_screen.dart';
@@ -33,6 +34,8 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Get.put(PermissionController());
+
     return GetMaterialApp(
       title: 'Ground Flip',
       theme: ThemeData(

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -15,7 +15,6 @@ class MapScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final MapController mapController = Get.put(MapController());
-    Get.put(PermissionController());
     Get.put(PixelInfoController());
     Get.put(WalkingController());
 

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -3,7 +3,6 @@ import 'package:get/get.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import '../controllers/map_controller.dart';
-import '../controllers/permission_controller.dart';
 import '../controllers/pixel_info_controller.dart';
 import '../controllers/walking_controller.dart';
 import '../widgets/map/mode_change_button.dart';


### PR DESCRIPTION
## 작업 내용*
- 권한을 거부 시 앱이 강제 종료되게끔 설정
- 앱에 필요한 권한을 앱 실행 시 구동하게끔 함.
## 고민한 내용*
- map controller 이전에 Permission controller가 생성되어야 정상적으로 작동함.
- 따라서 Main 화면이 표시될 때 생성되도록 함.
- ios와 android의 강제 종료 코드가 다름. 또한 ios에선 강제종료를 권하지 않음
- 따라서 단순히 반복해서 권한을 요청하거나, 다음 화면으로 넘어가지 않게 하는 것이 최선일 것 같음.

- 기존에는 location package에서 권한을 획득했으나, 권한 부여 주체의 통일을 위해 permission handler를 사용함.
