### PR TITLE
M3-194 지도 탭에서 다른 탭으로 넘어 갔다 올 경우 픽셀이 표시되지 않는 문제

### DIFF
--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
@@ -16,7 +17,8 @@ import '../widgets/pixel.dart';
 class MapController extends GetxController {
   final PixelService pixelService = PixelService();
 
-  static const String darkMapStylePath = 'assets/map_style/dark_map_style_with_landmarks.txt';
+  static const String darkMapStylePath =
+      'assets/map_style/dark_map_style_with_landmarks.txt';
   static const String userMarkerId = 'USER';
   static const double maxZoomOutLevel = 14.0;
   static const double latPerPixel = 0.000724;
@@ -24,8 +26,8 @@ class MapController extends GetxController {
 
   final Location location = Location();
   late final String mapStyle;
-  Completer<GoogleMapController> completer = Completer();
 
+  GoogleMapController? googleMapController;
   late LocationData currentLocation;
   late CameraPosition currentCameraPosition;
   late Map<String, int> latestPixel;
@@ -199,8 +201,7 @@ class MapController extends GetxController {
   }
 
   Future<int> _getCurrentRadiusOfMap() async {
-    GoogleMapController googleMapController = await completer.future;
-    LatLngBounds visibleRegion = await googleMapController.getVisibleRegion();
+    LatLngBounds visibleRegion = await googleMapController!.getVisibleRegion();
 
     final LatLng topLeft = LatLng(
       visibleRegion.northeast.latitude,

--- a/lib/controllers/my_page_controller.dart
+++ b/lib/controllers/my_page_controller.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'package:location/location.dart';
 
 import '../models/user.dart';
 import '../models/user_pixel_count.dart';
@@ -7,15 +8,29 @@ import '../service/user_service.dart';
 class MyPageController extends GetxController {
   final UserService userService = UserService();
   final Rx<User> currentUserInfo = User().obs;
-  final Rx<UserPixelCount> userPixelCount = UserPixelCount().obs;
+  final RxInt currentPixelCount = 0.obs;
+  final RxInt accumulatePixelCount = 0.obs;
 
   @override
   Future<void> onInit() async {
     super.onInit();
     User userInfo = await userService.getCurrentUserInfo();
-    UserPixelCount userPixelLogInfo = await userService.getUserPixelCount();
     currentUserInfo.value = userInfo;
-    userPixelCount.value = userPixelLogInfo;
+    await _updatePixelCount();
+    _trackPixelCount();
+  }
+
+  _trackPixelCount() {
+    Location().onLocationChanged.listen((newLocation) async {
+      await _updatePixelCount();
+    });
+  }
+
+  _updatePixelCount() async {
+    UserPixelCount currentUserPixelCount =
+        await userService.getUserPixelCount();
+    currentPixelCount.value = currentUserPixelCount.currentPixelCount!;
+    accumulatePixelCount.value = currentUserPixelCount.accumulatePixelCount!;
   }
 
   getProfileImageURL() {
@@ -28,13 +43,5 @@ class MyPageController extends GetxController {
 
   String getCurrentUserCommunityName() {
     return currentUserInfo.value.communityName ?? "-";
-  }
-
-  int getCurrentUserPixel() {
-    return userPixelCount.value.currentPixelCount ?? 0;
-  }
-
-  int getAccumulateUserPixel() {
-    return userPixelCount.value.accumulatePixelCount ?? 0;
   }
 }

--- a/lib/controllers/permission_controller.dart
+++ b/lib/controllers/permission_controller.dart
@@ -43,10 +43,10 @@ class PermissionController extends GetxController {
   }
 
   Future<void> requestIosPermissions() async {
-    Map<Permission, PermissionStatus> iosPermissionStatus = await [
+    await [
       Permission.location,
     ].request();
     final types = [HealthDataType.STEPS];
-    bool requested = await Health().requestAuthorization(types);
+    await Health().requestAuthorization(types);
   }
 }

--- a/lib/controllers/permission_controller.dart
+++ b/lib/controllers/permission_controller.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
-
+import 'package:health/health.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 class PermissionController extends GetxController {
@@ -45,13 +45,8 @@ class PermissionController extends GetxController {
   Future<void> requestIosPermissions() async {
     Map<Permission, PermissionStatus> iosPermissionStatus = await [
       Permission.location,
-      Permission.sensors,
     ].request();
-
-    for (PermissionStatus status in iosPermissionStatus.values) {
-      if (status.isDenied || status.isPermanentlyDenied) {
-        exitApp();
-      }
-    }
+    final types = [HealthDataType.STEPS];
+    bool requested = await Health().requestAuthorization(types);
   }
 }

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -26,26 +26,28 @@ class MapScreen extends StatelessWidget {
         } else {
           return Stack(
             children: [
-              GoogleMap(
-                mapType: MapType.normal,
-                myLocationButtonEnabled: true,
-                myLocationEnabled: true,
-                initialCameraPosition: CameraPosition(
-                  target: LatLng(
-                    mapController.currentLocation.latitude!,
-                    mapController.currentLocation.longitude!,
+              Obx(() {
+                return GoogleMap(
+                  mapType: MapType.normal,
+                  myLocationButtonEnabled: true,
+                  myLocationEnabled: true,
+                  initialCameraPosition: CameraPosition(
+                    target: LatLng(
+                      mapController.currentLocation.latitude!,
+                      mapController.currentLocation.longitude!,
+                    ),
+                    zoom: 16.0,
                   ),
-                  zoom: 16.0,
-                ),
-                onCameraMove: mapController.updateCameraPosition,
-                onCameraIdle: mapController.onCameraIdle,
-                onMapCreated: (GoogleMapController ctrl) {
-                  mapController.completer.complete(ctrl);
-                },
-                style: mapController.mapStyle,
-                markers: Set<Marker>.of(mapController.markers),
-                polygons: Set<Polygon>.of(mapController.pixels),
-              ),
+                  onCameraMove: mapController.updateCameraPosition,
+                  onCameraIdle: mapController.onCameraIdle,
+                  onMapCreated: (GoogleMapController ctrl) {
+                    mapController.googleMapController = ctrl;
+                  },
+                  style: mapController.mapStyle,
+                  markers: Set<Marker>.of(mapController.markers),
+                  polygons: Set<Polygon>.of(mapController.pixels),
+                );
+              }),
               Column(
                 children: [
                   const Padding(

--- a/lib/widgets/map/mode_change_button.dart
+++ b/lib/widgets/map/mode_change_button.dart
@@ -16,51 +16,53 @@ class ModeChangeButton extends StatelessWidget {
       child: Align(
         alignment: Alignment.topRight,
         child: DropdownButtonHideUnderline(
-          child: DropdownButton2<String>(
-            alignment: Alignment.center,
-            isExpanded: true,
-            items: PixelMode.values
-                .map(
-                  (PixelMode pixelMode) => DropdownMenuItem<String>(
-                    value: pixelMode.koreanName,
-                    child: Text(
-                      pixelMode.koreanName,
-                      style: const TextStyle(
-                        fontSize: 14,
-                        color: Colors.white,
+          child: Obx(() {
+            return DropdownButton2<String>(
+              alignment: Alignment.center,
+              isExpanded: true,
+              items: PixelMode.values
+                  .map(
+                    (PixelMode pixelMode) => DropdownMenuItem<String>(
+                      value: pixelMode.koreanName,
+                      child: Text(
+                        pixelMode.koreanName,
+                        style: const TextStyle(
+                          fontSize: 14,
+                          color: Colors.white,
+                        ),
                       ),
                     ),
-                  ),
-                )
-                .toList(),
-            onChanged: (pixelModeKrName) {
-              mapController.changePixelMode(pixelModeKrName!);
-            },
-            value: mapController.currentPixelMode.value.koreanName,
-            buttonStyleData: ButtonStyleData(
-              padding: EdgeInsets.symmetric(horizontal: 16),
-              height: 40,
-              width: 120,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(14),
-                color: Colors.blueAccent,
+                  )
+                  .toList(),
+              onChanged: (pixelModeKrName) {
+                mapController.changePixelMode(pixelModeKrName!);
+              },
+              value: mapController.currentPixelMode.value.koreanName,
+              buttonStyleData: ButtonStyleData(
+                padding: EdgeInsets.symmetric(horizontal: 16),
+                height: 40,
+                width: 120,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(14),
+                  color: Colors.blueAccent,
+                ),
               ),
-            ),
-            dropdownStyleData: DropdownStyleData(
-              maxHeight: 200,
-              width: 120,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(14),
-                color: Colors.blueAccent,
+              dropdownStyleData: DropdownStyleData(
+                maxHeight: 200,
+                width: 120,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(14),
+                  color: Colors.blueAccent,
+                ),
+                scrollbarTheme: ScrollbarThemeData(
+                  radius: const Radius.circular(40),
+                ),
               ),
-              scrollbarTheme: ScrollbarThemeData(
-                radius: const Radius.circular(40),
+              menuItemStyleData: const MenuItemStyleData(
+                height: 40,
               ),
-            ),
-            menuItemStyleData: const MenuItemStyleData(
-              height: 40,
-            ),
-          ),
+            );
+          }),
         ),
       ),
     );

--- a/lib/widgets/my_page/dash_board.dart
+++ b/lib/widgets/my_page/dash_board.dart
@@ -32,12 +32,12 @@ class DashBoard extends StatelessWidget {
             DashBoardWidget(
               textValue: "현재 픽셀수",
               iconImageUrl: "images/currentTile.png",
-              countValue: myPageController.getCurrentUserPixel().obs,
+              countValue: myPageController.currentPixelCount,
             ),
             DashBoardWidget(
               textValue: "누적 픽셀수",
               iconImageUrl: "images/allTile.png",
-              countValue: myPageController.getAccumulateUserPixel().obs,
+              countValue: myPageController.accumulatePixelCount,
             ),
             DashBoardWidget(
               textValue: "걸음수",

--- a/lib/widgets/my_page/dash_board_widget.dart
+++ b/lib/widgets/my_page/dash_board_widget.dart
@@ -36,8 +36,8 @@ class DashBoardWidget extends StatelessWidget {
             'assets/$iconImageUrl',
             width: 40,
             height: 40,
-          ), // () => Text('$countValue'),
-          Obx(() =>Text('${countValue.value}')),
+          ),
+          Obx(() => Text('${countValue.value}')),
         ],
       ),
     );


### PR DESCRIPTION
## 작업 내용*
- 지도 화면에서 다른 화면으로 넘어갔다오면 픽셀이 표시되지 않는 문제 발생
- 마이페이지의 현재 픽셀 정보 업데이트가 되지 않는 문제 
## 고민한 내용*
- 발생 원인
  - 구글 맵이 탭이 바뀔 때마다 계속 재 렌더링 되서 생긴 문제
- 해결 방법
  - GoogleMapController 를 계속 바꾸는 형식으로 변경
## 리뷰 요구사항
- 리뷰할 때 중점적으로 봐줬으면 하는 내용들
## 스크린샷