### PR TITLE
M3-196 회원가입, 로그인 텍스트입력, 버튼 수정

### DIFF
--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -26,18 +26,18 @@ class SignUpController extends GetxController {
   RxString gender = 'MALE'.obs;
   RxString nicknameValidation = "".obs;
   RxBool isNicknameTyped = false.obs;
+  RxInt isGender = 0.obs;
 
   @override
   void onInit() {
     textEditingController = TextEditingController();
     initTextFocusNode();
-    toggleSelection = [isMale, isFemale].obs;
     super.onInit();
   }
 
-  void initTextFocusNode(){
+  void initTextFocusNode() {
     textFocusNode.addListener(
-          () {
+      () {
         if (textFocusNode.hasFocus) {
           textEditingController.selection = TextSelection(
               baseOffset: 0, extentOffset: textEditingController.text.length);
@@ -59,14 +59,15 @@ class SignUpController extends GetxController {
     }
   }
 
-  void updateSelectedGender(int index) {
-    if (index == 0) {
-      toggleSelection.assignAll([true, false]);
-      gender.value = 'MALE';
-    } else {
-      toggleSelection.assignAll([false, true]);
+  void updateSelectedGender() {
+    if (isGender.value == 0) {
+      isGender.value = 1;
       gender.value = 'FEMALE';
+    } else {
+      isGender.value = 0;
+      gender.value = 'MALE';
     }
+    print('gendergender ${gender.value}');
   }
 
   void updateBirthYear(int inputBirthYear) {

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -40,7 +40,7 @@ class SignUpController extends GetxController {
       () {
         if (textFocusNode.hasFocus) {
           textEditingController.selection = TextSelection(
-              baseOffset: 0, extentOffset: textEditingController.text.length);
+              baseOffset: 0, extentOffset: textEditingController.text.length,);
         }
         if (!textFocusNode.hasFocus) {
           onSubmitted(textEditingController.text);

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -67,7 +67,6 @@ class SignUpController extends GetxController {
       isGender.value = 0;
       gender.value = 'MALE';
     }
-    print('gendergender ${gender.value}');
   }
 
   void updateBirthYear(int inputBirthYear) {

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -10,10 +10,12 @@ class SignUpController extends GetxController {
   final UserService userService = UserService();
   final ImagePicker picker = ImagePicker();
   final SecureStorage secureStorage = SecureStorage();
+  late final TextEditingController textEditingController;
+  final FocusNode textFocusNode = FocusNode();
 
   var profileImage = Rxn<XFile>();
 
-  final RegExp regExp = RegExp(r'^[A-Za-z가-힣0-9]{3,10}$');
+  final RegExp regExp = RegExp(r'^[A-Za-z가-힣0-9ㄱ-ㅎㅏ-ㅣ]{3,10}$');
 
   late RxList<bool> toggleSelection;
   bool isMale = true;
@@ -27,8 +29,24 @@ class SignUpController extends GetxController {
 
   @override
   void onInit() {
+    textEditingController = TextEditingController();
+    initTextFocusNode();
     toggleSelection = [isMale, isFemale].obs;
     super.onInit();
+  }
+
+  void initTextFocusNode(){
+    textFocusNode.addListener(
+          () {
+        if (textFocusNode.hasFocus) {
+          textEditingController.selection = TextSelection(
+              baseOffset: 0, extentOffset: textEditingController.text.length);
+        }
+        if (!textFocusNode.hasFocus) {
+          onSubmitted(textEditingController.text);
+        }
+      },
+    );
   }
 
   Future getImage() async {
@@ -102,6 +120,15 @@ class SignUpController extends GetxController {
           showErrorDialog('중복된 닉네임입니다!');
         }
       }
+    }
+  }
+
+  void onSubmitted(String value) {
+    updateNickname(value);
+    if (!regExp.hasMatch(value)) {
+      nicknameValidation.value = "형식에 맞지 않습니다!";
+    } else {
+      nicknameValidation.value = "";
     }
   }
 }

--- a/lib/controllers/user_info_controller.dart
+++ b/lib/controllers/user_info_controller.dart
@@ -55,7 +55,7 @@ class UserInfoController extends GetxController {
       () {
         if (textFocusNode.hasFocus) {
           textEditingController.selection = TextSelection(
-              baseOffset: 0, extentOffset: textEditingController.text.length);
+              baseOffset: 0, extentOffset: textEditingController.text.length,);
         }
         if (!textFocusNode.hasFocus) {
           onSubmitted(textEditingController.text);

--- a/lib/controllers/user_info_controller.dart
+++ b/lib/controllers/user_info_controller.dart
@@ -9,10 +9,12 @@ import '../service/user_service.dart';
 class UserInfoController extends GetxController {
   final UserService userService = UserService();
   final ImagePicker picker = ImagePicker();
+  late final TextEditingController textEditingController;
+  final FocusNode textFocusNode = FocusNode();
 
   late User user;
 
-  final RegExp regExp = RegExp(r'^[A-Za-z가-힣0-9]{3,10}$');
+  final RegExp regExp = RegExp(r'^[A-Za-z가-힣0-9ㄱ-ㅎㅏ-ㅣ]{3,10}$');
 
   var profileImage = Rxn<XFile>();
 
@@ -39,6 +41,15 @@ class UserInfoController extends GetxController {
       toggleSelection = [false, true].obs;
     }
     isUserInfoInit.value = true;
+    textFocusNode.addListener(() {
+      if (textFocusNode.hasFocus) {
+        textEditingController.selection = TextSelection(
+            baseOffset: 0, extentOffset: textEditingController.text.length);
+      }
+      if (!textFocusNode.hasFocus){
+        onSubmitted(textEditingController.text);
+      }
+    },);
     update();
   }
 
@@ -49,6 +60,7 @@ class UserInfoController extends GetxController {
     gender.value = user.gender ?? "MALE";
     imageS3Url.value = user.profileImageUrl ?? "";
     isInitImageUrl.value = true;
+    textEditingController = TextEditingController(text: nickname.value);
   }
 
   Future getImage() async {
@@ -112,7 +124,7 @@ class UserInfoController extends GetxController {
         Get.offAllNamed('/main');
       }
     } catch (e) {
-      if (!regExp.hasMatch(nickname.value)){
+      if (!regExp.hasMatch(nickname.value)) {
         showErrorDialog('닉네임 형식이 맞지 않습니다!');
       }
       if (e is DioException) {
@@ -121,6 +133,16 @@ class UserInfoController extends GetxController {
           showErrorDialog('중복된 닉네임입니다!');
         }
       }
+    }
+  }
+
+  void onSubmitted(String value){
+    nickname.value = value;
+    if (!regExp.hasMatch(value)) {
+      nicknameValidation.value =
+      "형식에 맞지 않습니다!";
+    } else {
+      nicknameValidation.value = "";
     }
   }
 }

--- a/lib/controllers/user_info_controller.dart
+++ b/lib/controllers/user_info_controller.dart
@@ -30,6 +30,7 @@ class UserInfoController extends GetxController {
   RxBool isNicknameTyped = false.obs;
   RxBool isUserInfoInit = false.obs;
   RxBool isInitImageUrl = false.obs;
+  RxInt isGender = 0.obs;
 
   @override
   void onInit() async {
@@ -41,17 +42,17 @@ class UserInfoController extends GetxController {
     update();
   }
 
-  void checkGender(){
+  void checkGender() {
     if (gender.value == "MALE") {
-      toggleSelection = [true, false].obs;
+      isGender.value = 0;
     } else {
-      toggleSelection = [false, true].obs;
+      isGender.value = 1;
     }
   }
 
-  void initTextFocusNode(){
+  void initTextFocusNode() {
     textFocusNode.addListener(
-          () {
+      () {
         if (textFocusNode.hasFocus) {
           textEditingController.selection = TextSelection(
               baseOffset: 0, extentOffset: textEditingController.text.length);
@@ -61,6 +62,16 @@ class UserInfoController extends GetxController {
         }
       },
     );
+  }
+
+  void updateSelectedGender() {
+    if (isGender.value == 0) {
+      isGender.value = 1;
+      gender.value = 'FEMALE';
+    } else {
+      isGender.value = 0;
+      gender.value = 'MALE';
+    }
   }
 
   Future<void> userInfoInit() async {
@@ -83,15 +94,15 @@ class UserInfoController extends GetxController {
     }
   }
 
-  void updateSelectedGender(int index) {
-    if (index == 0) {
-      toggleSelection.assignAll([true, false]);
-      gender.value = 'MALE';
-    } else {
-      toggleSelection.assignAll([false, true]);
-      gender.value = 'FEMALE';
-    }
-  }
+  // void updateSelectedGender(int index) {
+  //   if (index == 0) {
+  //     toggleSelection.assignAll([true, false]);
+  //     gender.value = 'MALE';
+  //   } else {
+  //     toggleSelection.assignAll([false, true]);
+  //     gender.value = 'FEMALE';
+  //   }
+  // }
 
   void updateBirthYear(int inputBirthYear) {
     birthYear.value = inputBirthYear;

--- a/lib/controllers/user_info_controller.dart
+++ b/lib/controllers/user_info_controller.dart
@@ -94,16 +94,6 @@ class UserInfoController extends GetxController {
     }
   }
 
-  // void updateSelectedGender(int index) {
-  //   if (index == 0) {
-  //     toggleSelection.assignAll([true, false]);
-  //     gender.value = 'MALE';
-  //   } else {
-  //     toggleSelection.assignAll([false, true]);
-  //     gender.value = 'FEMALE';
-  //   }
-  // }
-
   void updateBirthYear(int inputBirthYear) {
     birthYear.value = inputBirthYear;
   }

--- a/lib/controllers/user_info_controller.dart
+++ b/lib/controllers/user_info_controller.dart
@@ -35,22 +35,32 @@ class UserInfoController extends GetxController {
   void onInit() async {
     await userInfoInit();
     super.onInit();
+    checkGender();
+    isUserInfoInit.value = true;
+    initTextFocusNode();
+    update();
+  }
+
+  void checkGender(){
     if (gender.value == "MALE") {
       toggleSelection = [true, false].obs;
     } else {
       toggleSelection = [false, true].obs;
     }
-    isUserInfoInit.value = true;
-    textFocusNode.addListener(() {
-      if (textFocusNode.hasFocus) {
-        textEditingController.selection = TextSelection(
-            baseOffset: 0, extentOffset: textEditingController.text.length);
-      }
-      if (!textFocusNode.hasFocus){
-        onSubmitted(textEditingController.text);
-      }
-    },);
-    update();
+  }
+
+  void initTextFocusNode(){
+    textFocusNode.addListener(
+          () {
+        if (textFocusNode.hasFocus) {
+          textEditingController.selection = TextSelection(
+              baseOffset: 0, extentOffset: textEditingController.text.length);
+        }
+        if (!textFocusNode.hasFocus) {
+          onSubmitted(textEditingController.text);
+        }
+      },
+    );
   }
 
   Future<void> userInfoInit() async {
@@ -136,11 +146,10 @@ class UserInfoController extends GetxController {
     }
   }
 
-  void onSubmitted(String value){
+  void onSubmitted(String value) {
     nickname.value = value;
     if (!regExp.hasMatch(value)) {
-      nicknameValidation.value =
-      "형식에 맞지 않습니다!";
+      nicknameValidation.value = "형식에 맞지 않습니다!";
     } else {
       nicknameValidation.value = "";
     }

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -164,21 +164,29 @@ class SignUpScreen extends StatelessWidget {
                   ),
                   SizedBox(height: 4.0),
                   Obx(
-                    () => ToggleButtons(
-                      constraints: BoxConstraints.expand(
-                        width: (MediaQuery.of(context).size.width - 100) / 2,
-                      ), //
-                      isSelected: controller.toggleSelection,
-                      onPressed: controller.updateSelectedGender,
+                    () => Row(
                       children: [
-                        Text(
-                          '남성',
-                          style: TextStyle(fontSize: 16.0),
+                        ElevatedButton(
+                          onPressed: controller.isGender.value == 1
+                              ? controller.updateSelectedGender
+                              : null,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.grey,
+                            disabledBackgroundColor: Colors.redAccent,
+                          ),
+                          child: Text('남성'),
                         ),
-                        Text(
-                          '여성',
-                          style: TextStyle(fontSize: 16.0),
-                        ),
+                        SizedBox(width: 15),
+                        ElevatedButton(
+                          onPressed: controller.isGender.value == 0
+                              ? controller.updateSelectedGender
+                              : null,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.grey,
+                            disabledBackgroundColor: Colors.redAccent,
+                          ),
+                          child: Text('여성'),
+                        )
                       ],
                     ),
                   ),

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -12,7 +12,6 @@ class SignUpScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final SignUpController controller = Get.put(SignUpController());
-    final RegExp regExp = RegExp(r'^[A-Za-z가-힣0-9]{3,10}$');
     const int lowBoundYear = 1900;
     const int upperBoundYear = 2024;
 

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -81,6 +81,10 @@ class SignUpScreen extends StatelessWidget {
                   Container(
                     color: Color(0xffD9D9D9),
                     child: TextField(
+                      controller: controller.textEditingController,
+                      autofocus: true,
+                      focusNode: controller.textFocusNode,
+                      onSubmitted: controller.onSubmitted,
                       decoration: InputDecoration(
                         border: InputBorder.none,
                         contentPadding: EdgeInsets.symmetric(
@@ -89,14 +93,6 @@ class SignUpScreen extends StatelessWidget {
                         ),
                       ),
                       style: TextStyle(fontSize: 16.0),
-                      onChanged: (value) {
-                        controller.updateNickname(value);
-                        if (!regExp.hasMatch(value)) {
-                          controller.nicknameValidation.value = "형식에 맞지 않습니다!";
-                        } else {
-                          controller.nicknameValidation.value = "";
-                        }
-                      },
                     ),
                   ),
                   Align(

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -24,12 +24,6 @@ class SignUpScreen extends StatelessWidget {
         resizeToAvoidBottomInset: false,
         appBar: AppBar(
           title: Text('프로필 입력'),
-          leading: IconButton(
-            icon: Icon(Icons.arrow_back),
-            onPressed: () {
-              Get.previousRoute;
-            },
-          ),
         ),
         body: Padding(
           padding: const EdgeInsets.all(16.0),

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -186,7 +186,7 @@ class SignUpScreen extends StatelessWidget {
                             disabledBackgroundColor: Colors.redAccent,
                           ),
                           child: Text('여성'),
-                        )
+                        ),
                       ],
                     ),
                   ),

--- a/lib/screens/user_info_update_screen.dart
+++ b/lib/screens/user_info_update_screen.dart
@@ -198,7 +198,7 @@ class UserInfoUpdateScreen extends StatelessWidget {
                                 disabledBackgroundColor: Colors.redAccent,
                               ),
                               child: Text('여성'),
-                            )
+                            ),
                           ],
                         ),
                       ),

--- a/lib/screens/user_info_update_screen.dart
+++ b/lib/screens/user_info_update_screen.dart
@@ -176,22 +176,29 @@ class UserInfoUpdateScreen extends StatelessWidget {
                       ),
                       SizedBox(height: 4.0),
                       Obx(
-                        () => ToggleButtons(
-                          constraints: BoxConstraints.expand(
-                            width:
-                                (MediaQuery.of(context).size.width - 100) / 2,
-                          ), //
-                          isSelected: controller.toggleSelection,
-                          onPressed: controller.updateSelectedGender,
+                        () => Row(
                           children: [
-                            Text(
-                              '남성',
-                              style: TextStyle(fontSize: 16.0),
+                            ElevatedButton(
+                              onPressed: controller.isGender.value == 1
+                                  ? controller.updateSelectedGender
+                                  : null,
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: Colors.grey,
+                                disabledBackgroundColor: Colors.redAccent,
+                              ),
+                              child: Text('남성'),
                             ),
-                            Text(
-                              '여성',
-                              style: TextStyle(fontSize: 16.0),
-                            ),
+                            SizedBox(width: 15),
+                            ElevatedButton(
+                              onPressed: controller.isGender.value == 0
+                                  ? controller.updateSelectedGender
+                                  : null,
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: Colors.grey,
+                                disabledBackgroundColor: Colors.redAccent,
+                              ),
+                              child: Text('여성'),
+                            )
                           ],
                         ),
                       ),

--- a/lib/screens/user_info_update_screen.dart
+++ b/lib/screens/user_info_update_screen.dart
@@ -12,8 +12,6 @@ class UserInfoUpdateScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final UserInfoController controller = Get.put(UserInfoController());
-    final TextEditingController textEditingController = TextEditingController();
-    final RegExp regExp = RegExp(r'^[A-Za-z가-힣0-9]{3,10}$');
     const int lowBoundYear = 1900;
     const int upperBoundYear = 2024;
 
@@ -35,7 +33,7 @@ class UserInfoUpdateScreen extends StatelessWidget {
                   child: CircularProgressIndicator(),
                 );
               }
-              textEditingController.text = controller.nickname.value;
+              //controller.textEditingController.text = controller.nickname.value;
               return Column(
                 children: [
                   Obx(
@@ -95,7 +93,10 @@ class UserInfoUpdateScreen extends StatelessWidget {
                       Container(
                         color: Color(0xffD9D9D9),
                         child: TextField(
-                          controller: textEditingController,
+                          controller: controller.textEditingController,
+                          autofocus: true,
+                          focusNode: controller.textFocusNode,
+                          onSubmitted: controller.onSubmitted,
                           decoration: InputDecoration(
                             border: InputBorder.none,
                             contentPadding: EdgeInsets.symmetric(
@@ -104,15 +105,6 @@ class UserInfoUpdateScreen extends StatelessWidget {
                             ),
                           ),
                           style: TextStyle(fontSize: 16.0),
-                          onChanged: (value) {
-                            controller.nickname.value = value;
-                            if (!regExp.hasMatch(value)) {
-                              controller.nicknameValidation.value =
-                                  "형식에 맞지 않습니다!";
-                            } else {
-                              controller.nicknameValidation.value = "";
-                            }
-                          },
                         ),
                       ),
                       Align(

--- a/lib/screens/user_info_update_screen.dart
+++ b/lib/screens/user_info_update_screen.dart
@@ -12,7 +12,7 @@ class UserInfoUpdateScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final UserInfoController controller = Get.put(UserInfoController());
-    final TextEditingController controller0 = TextEditingController();
+    final TextEditingController textEditingController = TextEditingController();
     final RegExp regExp = RegExp(r'^[A-Za-z가-힣0-9]{3,10}$');
     const int lowBoundYear = 1900;
     const int upperBoundYear = 2024;
@@ -35,7 +35,7 @@ class UserInfoUpdateScreen extends StatelessWidget {
                   child: CircularProgressIndicator(),
                 );
               }
-              controller0.text = controller.nickname.value;
+              textEditingController.text = controller.nickname.value;
               return Column(
                 children: [
                   Obx(
@@ -95,7 +95,7 @@ class UserInfoUpdateScreen extends StatelessWidget {
                       Container(
                         color: Color(0xffD9D9D9),
                         child: TextField(
-                          controller: controller0,
+                          controller: textEditingController,
                           decoration: InputDecoration(
                             border: InputBorder.none,
                             contentPadding: EdgeInsets.symmetric(

--- a/lib/widgets/common/naviagtion_bar.dart
+++ b/lib/widgets/common/naviagtion_bar.dart
@@ -17,7 +17,7 @@ class CustomBottomNavigationBar extends GetView<NavigationController> {
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.map), label: "지도"),
           BottomNavigationBarItem(icon: Icon(Icons.leaderboard), label: "랭킹"),
-          // BottomNavigationBarItem(icon: Icon(Icons.group), label: "그룹"),
+          BottomNavigationBarItem(icon: Icon(Icons.group), label: "그룹"),
           BottomNavigationBarItem(
             icon: Icon(Icons.account_circle),
             label: "마이",

--- a/lib/widgets/my_page/user_info.dart
+++ b/lib/widgets/my_page/user_info.dart
@@ -13,8 +13,7 @@ class UserInfo extends StatelessWidget {
     final MyPageController myPageController = Get.find<MyPageController>();
     return InkWell(
       onTap: () {
-        //Get.to(() => UserInfoUpdateScreen());
-        Get.to(() => SignUpScreen());
+        Get.to(() => UserInfoUpdateScreen());
       },
       child: Ink(
         decoration: const BoxDecoration(

--- a/lib/widgets/my_page/user_info.dart
+++ b/lib/widgets/my_page/user_info.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../controllers/my_page_controller.dart';
-import '../../screens/sign_up_screen.dart';
 import '../../screens/user_info_update_screen.dart';
 
 class UserInfo extends StatelessWidget {

--- a/lib/widgets/my_page/user_info.dart
+++ b/lib/widgets/my_page/user_info.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../controllers/my_page_controller.dart';
+import '../../screens/sign_up_screen.dart';
 import '../../screens/user_info_update_screen.dart';
 
 class UserInfo extends StatelessWidget {
@@ -12,7 +13,8 @@ class UserInfo extends StatelessWidget {
     final MyPageController myPageController = Get.find<MyPageController>();
     return InkWell(
       onTap: () {
-        Get.to(() => UserInfoUpdateScreen());
+        //Get.to(() => UserInfoUpdateScreen());
+        Get.to(() => SignUpScreen());
       },
       child: Ink(
         decoration: const BoxDecoration(


### PR DESCRIPTION
## 작업 내용*
### 텍스트 입력
- 화면이 렌더링되고 닉네임에 자동으로 커서가 가있도록 한다
- 닉네임 텍스트 필드를 터치하면 텍스트 전체가 자동 선택되도록 한다
- 텍스트 필드에서 포커싱 아웃되면 엔터키를 누른것과 같은 이벤트(submitted)를 발생시킨다
- onSubmitted되면 닉네임을 validation한다
- 한글 자음, 모음만으로도 입력이 가능하게 한다

### 버튼
- 토글 버튼을 삭제하고 elevated button 2개를 생성한다
- 한 버튼을 누르면 한 버튼은 내려가게 한다
## 고민한 내용*
- 포커싱 아웃되면 onSubmitted함수와 같은 효과를 주기 위해 함수로 분리시켰다
- 한글 자음, 모음만으로도 닉네임 생성이 가능하도록 정규식을 변경했다
- textEditController를 getx컨트롤러에 포함시켰다. 이렇게 하지 않고 screen에서 생성하면 controller가 2개가 되어서 충돌이 발생했다.

- 기술적 고민
## 리뷰 요구사항
- 함수, 변수명
## 스크린샷
| ![image](https://github.com/user-attachments/assets/10248bc8-953e-4a7a-8bf2-19b05b1a5f40) |