### PR TITLE
M3-225 안드로이드 앱 번들 키 서명을 위한 build.gradle 수정

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,6 +4,12 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -54,11 +60,17 @@ android {
         multiDexEnabled true
     }
 
+    signingConfigs {
+        release {
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties['storePassword']
+        }
+    }
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
         }
     }
 }


### PR DESCRIPTION
## 작업 내용*
- 안드로이드 앱 서명을 위한 build.gradle 내용 추가
- build bundle을 성공시키려면 key.properties 파일과 my-release-key.jks파일이 추가로 필요하다
- key, password와 관련된 내용이라 git에 올리지 않는다
## 고민한 내용*

