### PR TITLE
M3-216 랭킹 화면에서 이전 랭킹 불러오는 기능 구현

### DIFF
--- a/lib/constants/text_styles.dart
+++ b/lib/constants/text_styles.dart
@@ -27,6 +27,12 @@ class TextStyles {
     fontWeight: FontWeight.w600,
   );
 
+  static TextStyle fs17w600cTextBlack = TextStyle(
+    color: AppColors.textBlack,
+    fontSize: 17,
+    fontWeight: FontWeight.w600,
+  );
+
   static TextStyle fs17w700cTextPrimary = TextStyle(
     fontSize: 17,
     fontWeight: FontWeight.w700,
@@ -55,6 +61,12 @@ class TextStyles {
     color: AppColors.primary,
     fontSize: 14,
     fontWeight: FontWeight.w500,
+  );
+
+  static TextStyle fs14w800cTextPrimary = TextStyle(
+    color: AppColors.textPrimary,
+    fontSize: 14,
+    fontWeight: FontWeight.w800,
   );
 
   static TextStyle fs14w500cTextSecondary = TextStyle(

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -184,7 +184,7 @@ class MapController extends GetxController {
   }
 
   void _trackPixels() {
-    Timer.periodic(const Duration(seconds: 30), (timer) {
+    Timer.periodic(const Duration(seconds: 10), (timer) {
       updatePixels();
     });
   }
@@ -206,6 +206,7 @@ class MapController extends GetxController {
       case PixelMode.groupMode:
         break;
     }
+    await updateCurrentPixel();
   }
 
   bool _isMapOverZoomedOut() => currentCameraPosition.zoom < maxZoomOutLevel;

--- a/lib/controllers/ranking_controller.dart
+++ b/lib/controllers/ranking_controller.dart
@@ -41,7 +41,9 @@ class RankingController extends GetxController {
     List<Ranking> rankings =
         await rankingService.getAllUserRanking(selectedWeek);
     Ranking myRanking = await rankingService.getUserRanking(
-        UserManager().getUserId()!, selectedWeek);
+      UserManager().getUserId()!,
+      selectedWeek,
+    );
     this.rankings.assignAll(rankings);
     this.myRanking = myRanking.obs;
     isLoading.value = false;
@@ -51,7 +53,9 @@ class RankingController extends GetxController {
     List<Ranking> rankings =
         await rankingService.getAllUserRanking(selectedWeek);
     Ranking myRanking = await rankingService.getUserRanking(
-        UserManager().getUserId()!, selectedWeek);
+      UserManager().getUserId()!,
+      selectedWeek,
+    );
     await Future.delayed(Duration(seconds: seconds));
     this.rankings.assignAll(rankings);
     this.myRanking.value = myRanking;

--- a/lib/controllers/ranking_controller.dart
+++ b/lib/controllers/ranking_controller.dart
@@ -76,7 +76,11 @@ class RankingController extends GetxController {
   }
 
   getRankingsAll() {
-    return rankings.sublist(3);
+    if (rankings.length >= 3) {
+      return rankings.sublist(3);
+    } else {
+      return rankings.toList();
+    }
   }
 
   selectWeek(int selectedWeekNumber, DateTime selectedWeek) {

--- a/lib/controllers/ranking_controller.dart
+++ b/lib/controllers/ranking_controller.dart
@@ -38,18 +38,20 @@ class RankingController extends GetxController {
 
   _initRanking() async {
     isLoading.value = true;
-    List<Ranking> rankings = await rankingService.getAllUserRanking();
-    Ranking myRanking =
-        await rankingService.getUserRanking(UserManager().getUserId()!);
+    List<Ranking> rankings =
+        await rankingService.getAllUserRanking(selectedWeek);
+    Ranking myRanking = await rankingService.getUserRanking(
+        UserManager().getUserId()!, selectedWeek);
     this.rankings.assignAll(rankings);
     this.myRanking = myRanking.obs;
     isLoading.value = false;
   }
 
   updateRankingWithDelay(int seconds) async {
-    List<Ranking> rankings = await rankingService.getAllUserRanking();
-    Ranking myRanking =
-        await rankingService.getUserRanking(UserManager().getUserId()!);
+    List<Ranking> rankings =
+        await rankingService.getAllUserRanking(selectedWeek);
+    Ranking myRanking = await rankingService.getUserRanking(
+        UserManager().getUserId()!, selectedWeek);
     await Future.delayed(Duration(seconds: seconds));
     this.rankings.assignAll(rankings);
     this.myRanking.value = myRanking;

--- a/lib/models/ranking.dart
+++ b/lib/models/ranking.dart
@@ -2,8 +2,8 @@ class Ranking {
   int userId;
   String nickname;
   String? profileImageUrl;
-  int rank;
-  int currentPixelCount;
+  int? rank;
+  int? currentPixelCount;
 
   Ranking({
     required this.userId,

--- a/lib/screens/policy_screen.dart
+++ b/lib/screens/policy_screen.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:ground_flip/screens/sign_up_screen.dart';
 
 import '../constants/app_colors.dart';
 import '../constants/text_styles.dart';
 import '../controllers/policy_controller.dart';
 import '../widgets/policy/check_policy.dart';
 import '../widgets/policy/policy_all_check.dart';
+import 'sign_up_screen.dart';
 
 class PolicyScreen extends StatelessWidget {
   const PolicyScreen({super.key});
@@ -87,7 +87,7 @@ class PolicyScreen extends StatelessWidget {
               ),
               SizedBox(
                 height: 30,
-              )
+              ),
             ],
           ),
         ),

--- a/lib/service/ranking_service.dart
+++ b/lib/service/ranking_service.dart
@@ -13,14 +13,26 @@ class RankingService {
     return _instance;
   }
 
-  getAllUserRanking() async {
-    var response = await dio.get('/ranking/user');
+  getAllUserRanking(DateTime lookupDate) async {
+    var response = await dio.get(
+      '/ranking/user',
+      queryParameters: {
+        'lookup-date':
+            '${lookupDate.year}-${lookupDate.month.toString().padLeft(2, '0')}-${lookupDate.day.toString().padLeft(2, '0')}',
+      },
+    );
 
     return Ranking.listFromJson(response.data['data']);
   }
 
-  getUserRanking(int userId) async {
-    var response = await dio.get('/ranking/user/${userId.toString()}');
+  getUserRanking(int userId, DateTime lookupDate) async {
+    var response = await dio.get(
+      '/ranking/user/${userId.toString()}',
+      queryParameters: {
+        'lookup-date':
+            '${lookupDate.year}-${lookupDate.month.toString().padLeft(2, '0')}-${lookupDate.day.toString().padLeft(2, '0')}',
+      },
+    );
 
     return Ranking.fromJson(response.data['data']);
   }

--- a/lib/widgets/map/bottom_sheet/no_ranker_message.dart
+++ b/lib/widgets/map/bottom_sheet/no_ranker_message.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/cupertino.dart';
+
+import '../../../constants/app_colors.dart';
+import '../../../constants/text_styles.dart';
+
+class NoRankerMessage extends StatelessWidget {
+  const NoRankerMessage({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20.0),
+      decoration: BoxDecoration(
+        color: AppColors.backgroundThird,
+        borderRadius: BorderRadius.all(Radius.circular(16)),
+      ),
+      child: Center(
+        child: Column(
+          children: [
+            Text(
+              "이 주차의 순위가 없습니다.",
+              style: TextStyles.fs20w700cTextPrimary,
+            ),
+            Text(
+              "다른 날짜를 선택해주세요!",
+              style: TextStyles.fs17w700cPrimary,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/ranking/my_ranking_info.dart
+++ b/lib/widgets/ranking/my_ranking_info.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:ground_flip/widgets/ranking/ranking_info.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
 import '../../controllers/ranking_controller.dart';
-import 'ranking_info.dart';
 
 class MyRankingInfo extends StatelessWidget {
   const MyRankingInfo({super.key});
@@ -16,26 +16,22 @@ class MyRankingInfo extends StatelessWidget {
     return Obx(() {
       return Container(
         decoration: BoxDecoration(
-          border: Border.all(
-            color: Color.lerp(
+          gradient: LinearGradient(
+            colors: [
+              AppColors.secondary,
               AppColors.primary,
-              AppColors.background,
-              rankingController.t.value,
-            )!, // 경계선 색상
-            width: 1,
-          ),
-          color: Color.lerp(
-            AppColors.backgroundSecondary,
-            AppColors.background,
-            rankingController.t.value,
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
           ),
           borderRadius: BorderRadius.all(Radius.circular(16)),
         ),
         child: Padding(
-          padding: EdgeInsets.all(rankingController.myRankingInfoPadding.value),
+          // padding: EdgeInsets.all(rankingController.myRankingInfoPadding.value),
+          padding: EdgeInsets.all(20),
           child: Column(
             children: [
-              RankingInfo(
+              RankingInfoMy(
                 ranking: rankingController.getMyRanking(),
               ),
               SizedBox(height: rankingController.myRankingInfoPadding.value),
@@ -43,7 +39,7 @@ class MyRankingInfo extends StatelessWidget {
                 padding: EdgeInsets.symmetric(vertical: 0.0, horizontal: 16.0),
                 height: rankingController.myRankingInfoHeight.value,
                 decoration: BoxDecoration(
-                  color: AppColors.secondary,
+                  color: Color(0x80333333),
                   borderRadius: BorderRadius.circular(20.0),
                 ),
                 child: Row(
@@ -51,8 +47,8 @@ class MyRankingInfo extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     Text(
-                      '3px 더 먹으면 순위 상승!',
-                      style: TextStyles.fs14w500cPrimary,
+                      '오늘 하루도 파이팅!',
+                      style: TextStyles.fs14w800cTextPrimary,
                     ),
                   ],
                 ),

--- a/lib/widgets/ranking/my_ranking_info.dart
+++ b/lib/widgets/ranking/my_ranking_info.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:ground_flip/widgets/ranking/ranking_info.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
 import '../../controllers/ranking_controller.dart';
+import 'ranking_info.dart';
 
 class MyRankingInfo extends StatelessWidget {
   const MyRankingInfo({super.key});

--- a/lib/widgets/ranking/ranking_info.dart
+++ b/lib/widgets/ranking/ranking_info.dart
@@ -1,12 +1,98 @@
 import 'package:flutter/cupertino.dart';
 import 'package:intl/intl.dart';
 
-import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
 import '../../models/ranking.dart';
 
 class RankingInfo extends StatelessWidget {
   const RankingInfo({
+    super.key,
+    required this.ranking,
+  });
+
+  final Ranking ranking;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Rank(rank: ranking.rank),
+        SizedBox(width: 10),
+        ClipOval(
+          child: ranking.profileImageUrl != null
+              ? Image.network(
+                  ranking.profileImageUrl!,
+                  cacheWidth: 100,
+                  width: 30,
+                  height: 30,
+                  fit: BoxFit.cover,
+                )
+              : Image.asset(
+                  'assets/images/default_profile_image.png',
+                  width: 30,
+                  height: 30,
+                ),
+        ),
+        SizedBox(width: 10),
+        Expanded(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(ranking.nickname, style: TextStyles.fs17w600cTextPrimary),
+              Spacer(),
+              if (ranking.currentPixelCount != null)
+                Text(
+                  '${NumberFormat('###,###,###').format(ranking.currentPixelCount)}px',
+                  style: TextStyles.fs17w700cPrimary,
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class Rank extends StatelessWidget {
+  static List<String> medalImages = [
+    "assets/images/1st_place_medal.png",
+    "assets/images/2nd_place_medal.png",
+    "assets/images/3rd_place_medal.png",
+  ];
+  final int? rank;
+
+  const Rank({super.key, required this.rank});
+
+  @override
+  Widget build(BuildContext context) {
+    if (rank == null) {
+      return SizedBox(
+        width: 30,
+        height: 30,
+        child: Center(
+          child: Text('?', style: TextStyles.fs20w800cTextPrimary),
+        ),
+      );
+    } else if (rank! <= 3 && rank! >= 1) {
+      return Image.asset(
+        medalImages[rank! - 1],
+        width: 30,
+        height: 30,
+      );
+    } else {
+      return SizedBox(
+        width: 30,
+        height: 30,
+        child: Center(
+          child: Text(rank.toString(), style: TextStyles.fs20w800cTextPrimary),
+        ),
+      );
+    }
+  }
+}
+
+class RankingInfoMy extends StatelessWidget {
+  const RankingInfoMy({
     super.key,
     required this.ranking,
   });
@@ -46,13 +132,13 @@ class RankingInfo extends StatelessWidget {
             ],
           ),
         ),
-        Rank(rank: ranking.rank),
+        MyRank(rank: ranking.rank),
       ],
     );
   }
 }
 
-class Rank extends StatelessWidget {
+class MyRank extends StatelessWidget {
   static List<String> medalImages = [
     "assets/images/1st_place_medal.png",
     "assets/images/2nd_place_medal.png",
@@ -60,7 +146,7 @@ class Rank extends StatelessWidget {
   ];
   final int? rank;
 
-  const Rank({super.key, required this.rank});
+  const MyRank({super.key, required this.rank});
 
   @override
   Widget build(BuildContext context) {
@@ -69,7 +155,7 @@ class Rank extends StatelessWidget {
         width: 44,
         height: 44,
         decoration: BoxDecoration(
-          color: AppColors.backgroundThird,
+          color: Color(0x80333333),
           borderRadius: BorderRadius.all(Radius.circular(22)),
         ),
         child: Center(
@@ -87,7 +173,7 @@ class Rank extends StatelessWidget {
         width: 44,
         height: 44,
         decoration: BoxDecoration(
-          color: AppColors.backgroundThird,
+          color: Color(0x80333333),
           borderRadius: BorderRadius.all(Radius.circular(22)),
         ),
         child: Center(

--- a/lib/widgets/ranking/ranking_info.dart
+++ b/lib/widgets/ranking/ranking_info.dart
@@ -38,10 +38,11 @@ class RankingInfo extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(ranking.nickname, style: TextStyles.fs17w600cTextPrimary),
-              Text(
-                '${NumberFormat('###,###,###').format(ranking.currentPixelCount)}px',
-                style: TextStyles.fs14w500cPrimary,
-              ),
+              if (ranking.currentPixelCount != null)
+                Text(
+                  '${NumberFormat('###,###,###').format(ranking.currentPixelCount)}px',
+                  style: TextStyles.fs14w500cPrimary,
+                ),
             ],
           ),
         ),
@@ -57,15 +58,27 @@ class Rank extends StatelessWidget {
     "assets/images/2nd_place_medal.png",
     "assets/images/3rd_place_medal.png",
   ];
-  final int rank;
+  final int? rank;
 
   const Rank({super.key, required this.rank});
 
   @override
   Widget build(BuildContext context) {
-    if (rank <= 3 && rank >= 1) {
+    if (rank == null) {
+      return Container(
+        width: 44,
+        height: 44,
+        decoration: BoxDecoration(
+          color: AppColors.backgroundThird,
+          borderRadius: BorderRadius.all(Radius.circular(22)),
+        ),
+        child: Center(
+          child: Text('?', style: TextStyles.fs20w800cTextPrimary),
+        ),
+      );
+    } else if (rank! <= 3 && rank! >= 1) {
       return Image.asset(
-        medalImages[rank - 1],
+        medalImages[rank! - 1],
         width: 44,
         height: 44,
       );

--- a/lib/widgets/ranking/ranking_list.dart
+++ b/lib/widgets/ranking/ranking_list.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 
 import '../../constants/app_colors.dart';
 import '../../controllers/ranking_controller.dart';
+import '../map/bottom_sheet/no_ranker_message.dart';
 import 'ranking_list_element.dart';
 
 class RankingList extends StatelessWidget {
@@ -22,6 +23,13 @@ class RankingList extends StatelessWidget {
         child: ListView(
           controller: rankingController.scrollController,
           children: [
+            Obx(() {
+              if (rankingController.rankings.isEmpty) {
+                return NoRankerMessage();
+              } else {
+                return Container();
+              }
+            }),
             Obx(() {
               return RankingSection(
                 rankings: rankingController.getRankingsTop3(),

--- a/lib/widgets/ranking/ranking_list.dart
+++ b/lib/widgets/ranking/ranking_list.dart
@@ -70,7 +70,7 @@ class RankingSection extends StatelessWidget {
           for (int i = 0; i < rankings.length; i++)
             RankingListElement(
               ranking: rankings[i],
-              isLast: false,
+              isLast: i == rankings.length - 1 ? true : false,
             ),
         ],
       ),

--- a/lib/widgets/ranking/ranking_list_element.dart
+++ b/lib/widgets/ranking/ranking_list_element.dart
@@ -30,7 +30,7 @@ class RankingListElement extends StatelessWidget {
           ),
         ),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 20),
+          padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 16),
           child: RankingInfo(
             ranking: ranking,
           ),


### PR DESCRIPTION
## 작업 내용*
- 이전 랭킹을 불러오는 기능 구현
- 디자인 변경
## 고민한 내용*
- 디자인이 심심해서 수정
- 이전 랭킹이 없으면 없다는 문구 추가
## 리뷰 요구사항
- 리뷰할 때 중점적으로 봐줬으면 하는 내용들
## 스크린샷
| ![Simulator Screenshot - iPhone 15 Pro - 2024-07-25 at 14 21 59](https://github.com/user-attachments/assets/674acdfb-d492-4217-baa7-bea66a9c1ca4) | ![Simulator Screenshot - iPhone 15 Pro - 2024-07-25 at 14 22 09](https://github.com/user-attachments/assets/f83b0458-08ee-4c40-b4f9-83babcda83c9) |  ![Simulator Screenshot - iPhone 15 Pro - 2024-07-25 at 14 22 40](https://github.com/user-attachments/assets/22d83061-650c-4667-ad6c-27633489af59) |
|----|----|----|

