### PR TITLE
M3-245 iOS 걸음수를 불러오지 못하는 오류 해결

### DIFF
--- a/lib/controllers/walking_controller.dart
+++ b/lib/controllers/walking_controller.dart
@@ -32,7 +32,7 @@ class WalkingController extends GetxController {
   }
 
   void _initializeUpdateTimer() {
-    int updateInterval = Platform.isIOS ? 60 : 1;
+    int updateInterval = Platform.isIOS ? 15 : 1;
     Timer.periodic(Duration(seconds: updateInterval), (timer) {
       updateCurrentStep();
     });

--- a/lib/service/ios_walking_service.dart
+++ b/lib/service/ios_walking_service.dart
@@ -20,8 +20,9 @@ class IosWalkingService implements WalkingService {
   @override
   Future<int> getCurrentStep() async {
     final now = DateTime.now();
-    final startTime = DateTime(now.year, now.month, now.day);
-    int steps = await Health().getTotalStepsInInterval(startTime, now) ?? 0;
+    final startTime = DateTime(now.year, now.month, now.day, 0, 0, 0);
+    final endTime = DateTime(now.year, now.month, now.day, 23, 59, 59);
+    int steps = await Health().getTotalStepsInInterval(startTime, endTime) ?? 0;
     return steps;
   }
 
@@ -44,5 +45,4 @@ class IosWalkingService implements WalkingService {
 
     return dailySteps;
   }
-
 }


### PR DESCRIPTION
## 작업 내용*
-  iOS 걸음수를 불러오지 못하는 오류 해결
- 걸음수 업데이트 주기 15초로 변경
## 고민한 내용*
### 발생 원인

- 원인은 정확하게 찾지 못했다.

- 주간 걸음수 통계에서는 오늘의 걸음이 잘나오고 현재 걸음수 함수에서는 안나오는 것을 보고 문제점을 찾았지만 정확히 어떤 이유로 안나오는지는 못찾았다.

### 해결 방법

- 오늘 걸음수를 가져올 때 걸음수의 범위를 오늘 00:00:00 부터 now() 까지가 아니라 23:59:59 로 불러온다.
```
int steps = await Health().getTotalStepsInInterval(startTime, now) ?? 0;
```
```
      DateTime startOfDay = DateTime(date.year, date.month, date.day, 0, 0, 0);
      DateTime endOfDay = DateTime(date.year, date.month, date.day, 23, 59, 59);
      int dailyStep =
          await Health().getTotalStepsInInterval(startOfDay, endOfDay) ?? 0;
```
## 리뷰 요구사항
- 리뷰할 때 중점적으로 봐줬으면 하는 내용들
## 스크린샷