### PR TITLE
M3-282 인터넷이 5초안에 복구되면 경고창이 뜨지 않음

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -39,14 +41,25 @@ class MyApp extends StatelessWidget {
   MyApp({super.key, required this.initialRoute});
 
   final String initialRoute;
+  static bool checkInternet = true;
+
   final listener =
       InternetConnection().onStatusChange.listen((InternetStatus status) {
     switch (status) {
       case InternetStatus.connected:
+        checkInternet = true;
         break;
       case InternetStatus.disconnected:
-        Get.dialog(
-          InternetDisconnect(),
+        checkInternet = false;
+        Timer(
+          Duration(seconds: 5),
+          () {
+            if(!checkInternet){
+              Get.dialog(
+                InternetDisconnect(),
+              );
+            }
+          },
         );
         break;
     }


### PR DESCRIPTION
## 작업 내용*
- 인터넷 연결이 끊겼다가 5초 이내로 복구되면 alert창이 뜨지 않음
## 고민한 내용*
- 원래 event listener로만 구현을 했는데 timer와 상태를 나타내는 변수를 사용해 
- 5초 이내에 복구되면 alert창이 뜨지 않도록 했다.
