### PR TITLE
M3-275 픽셀 겹치는 문제 해결

### DIFF
--- a/lib/widgets/pixel.dart
+++ b/lib/widgets/pixel.dart
@@ -17,10 +17,12 @@ import '../utils/user_manager.dart';
 class Pixel extends Polygon {
   static const double latPerPixel = 0.000724;
   static const double lonPerPixel = 0.000909;
-  static const int defaultStrokeWidth = 2;
-
   static const double defaultStrokeWidthToLatitude = 0.00000905;
   static const double defaultStrokeWidthToLongitude = 0.0000113625;
+
+  static const int defaultStrokeWidth = 2;
+  static const double defaultZoomLevel = 16.0;
+
   final int x;
   final int y;
   final int pixelId;
@@ -53,7 +55,7 @@ class Pixel extends Polygon {
       y: 0,
       pixelId: 1,
       points: List<LatLng>.from({LatLng(0.0, 0.0)}),
-      customOnTap: (int pixelId) {  },
+      customOnTap: (int pixelId) {},
       polygonId: '1',
     );
   }
@@ -63,7 +65,8 @@ class Pixel extends Polygon {
       x: pixel.x,
       y: pixel.y,
       pixelId: pixel.pixelId,
-      customOnTap: (int pixelId) => (pixel.onTap != null) ? (pixel.onTap!)() : {},
+      customOnTap: (int pixelId) =>
+          (pixel.onTap != null) ? (pixel.onTap!)() : {},
       polygonId: pixel.polygonId.value,
       points: List<LatLng>.from(pixel.points),
       geodesic: pixel.geodesic,
@@ -94,7 +97,8 @@ class Pixel extends Polygon {
       strokeColor: isMyPixel ? Color(0xFF0DF69E) : Colors.red,
       strokeWidth: defaultStrokeWidth,
       customOnTap: (int pixelId) async {
-        FirebaseAnalytics.instance.logEvent(name: "individual_mode_pixel_click");
+        FirebaseAnalytics.instance
+            .logEvent(name: "individual_mode_pixel_click");
 
         Get.find<MapController>().changePixelToOnTabState(pixelId);
 
@@ -139,14 +143,27 @@ class Pixel extends Polygon {
   }
 
   static List<LatLng> _getRectangleFromLatLng({required LatLng topLeftPoint}) {
+    double currentZoomLevel =
+        Get.find<MapController>().currentCameraPosition.zoom;
+
+    num zoomScale = (16.0 - currentZoomLevel) >= 0
+        ? pow(2, (defaultZoomLevel - currentZoomLevel))
+        : 1;
+
+    double strokeWidthToLatitude = defaultStrokeWidthToLatitude * zoomScale;
+    double strokeWidthToLongitude = defaultStrokeWidthToLongitude * zoomScale;
+
     return List<LatLng>.of({
-      LatLng(topLeftPoint.latitude - defaultStrokeWidthToLatitude, topLeftPoint.longitude + defaultStrokeWidthToLongitude),
-      LatLng(topLeftPoint.latitude - defaultStrokeWidthToLatitude, topLeftPoint.longitude + lonPerPixel - defaultStrokeWidthToLongitude),
+      LatLng(topLeftPoint.latitude - strokeWidthToLatitude,
+          topLeftPoint.longitude + strokeWidthToLongitude),
+      LatLng(topLeftPoint.latitude - strokeWidthToLatitude,
+          topLeftPoint.longitude + lonPerPixel - strokeWidthToLongitude),
       LatLng(
-        topLeftPoint.latitude - latPerPixel + defaultStrokeWidthToLatitude,
-        topLeftPoint.longitude + lonPerPixel - defaultStrokeWidthToLongitude,
+        topLeftPoint.latitude - latPerPixel + strokeWidthToLatitude,
+        topLeftPoint.longitude + lonPerPixel - strokeWidthToLongitude,
       ),
-      LatLng(topLeftPoint.latitude - latPerPixel + defaultStrokeWidthToLatitude, topLeftPoint.longitude + defaultStrokeWidthToLongitude),
+      LatLng(topLeftPoint.latitude - latPerPixel + strokeWidthToLatitude,
+          topLeftPoint.longitude + strokeWidthToLongitude),
     });
   }
 
@@ -157,8 +174,7 @@ class Pixel extends Polygon {
       pixelId: pixel.pixelId,
       polygonId: pixel.pixelId.toString(),
       points: pixel.points,
-      fillColor: Colors.white
-          .withOpacity(0.3),
+      fillColor: Colors.white.withOpacity(0.3),
       strokeColor: Colors.white,
       strokeWidth: defaultStrokeWidth,
       customOnTap: (pixelId) {},

--- a/lib/widgets/pixel.dart
+++ b/lib/widgets/pixel.dart
@@ -19,8 +19,8 @@ class Pixel extends Polygon {
   static const double lonPerPixel = 0.000909;
   static const int defaultStrokeWidth = 2;
 
-  static const double strokeWidthToLatitude = 0.00000905;
-  static const double strokeWidthToLongitude = 0.0000113625;
+  static const double defaultStrokeWidthToLatitude = 0.00000905;
+  static const double defaultStrokeWidthToLongitude = 0.0000113625;
   final int x;
   final int y;
   final int pixelId;
@@ -140,13 +140,13 @@ class Pixel extends Polygon {
 
   static List<LatLng> _getRectangleFromLatLng({required LatLng topLeftPoint}) {
     return List<LatLng>.of({
-      LatLng(topLeftPoint.latitude - strokeWidthToLatitude, topLeftPoint.longitude + strokeWidthToLongitude),
-      LatLng(topLeftPoint.latitude - strokeWidthToLatitude, topLeftPoint.longitude + lonPerPixel - strokeWidthToLongitude),
+      LatLng(topLeftPoint.latitude - defaultStrokeWidthToLatitude, topLeftPoint.longitude + defaultStrokeWidthToLongitude),
+      LatLng(topLeftPoint.latitude - defaultStrokeWidthToLatitude, topLeftPoint.longitude + lonPerPixel - defaultStrokeWidthToLongitude),
       LatLng(
-        topLeftPoint.latitude - latPerPixel + strokeWidthToLatitude,
-        topLeftPoint.longitude + lonPerPixel - strokeWidthToLongitude,
+        topLeftPoint.latitude - latPerPixel + defaultStrokeWidthToLatitude,
+        topLeftPoint.longitude + lonPerPixel - defaultStrokeWidthToLongitude,
       ),
-      LatLng(topLeftPoint.latitude - latPerPixel + strokeWidthToLatitude, topLeftPoint.longitude + strokeWidthToLongitude),
+      LatLng(topLeftPoint.latitude - latPerPixel + defaultStrokeWidthToLatitude, topLeftPoint.longitude + defaultStrokeWidthToLongitude),
     });
   }
 

--- a/lib/widgets/pixel.dart
+++ b/lib/widgets/pixel.dart
@@ -154,16 +154,22 @@ class Pixel extends Polygon {
     double strokeWidthToLongitude = defaultStrokeWidthToLongitude * zoomScale;
 
     return List<LatLng>.of({
-      LatLng(topLeftPoint.latitude - strokeWidthToLatitude,
-          topLeftPoint.longitude + strokeWidthToLongitude),
-      LatLng(topLeftPoint.latitude - strokeWidthToLatitude,
-          topLeftPoint.longitude + lonPerPixel - strokeWidthToLongitude),
+      LatLng(
+        topLeftPoint.latitude - strokeWidthToLatitude,
+        topLeftPoint.longitude + strokeWidthToLongitude,
+      ),
+      LatLng(
+        topLeftPoint.latitude - strokeWidthToLatitude,
+        topLeftPoint.longitude + lonPerPixel - strokeWidthToLongitude,
+      ),
       LatLng(
         topLeftPoint.latitude - latPerPixel + strokeWidthToLatitude,
         topLeftPoint.longitude + lonPerPixel - strokeWidthToLongitude,
       ),
-      LatLng(topLeftPoint.latitude - latPerPixel + strokeWidthToLatitude,
-          topLeftPoint.longitude + strokeWidthToLongitude),
+      LatLng(
+        topLeftPoint.latitude - latPerPixel + strokeWidthToLatitude,
+        topLeftPoint.longitude + strokeWidthToLongitude,
+      ),
     });
   }
 

--- a/lib/widgets/pixel.dart
+++ b/lib/widgets/pixel.dart
@@ -17,7 +17,10 @@ import '../utils/user_manager.dart';
 class Pixel extends Polygon {
   static const double latPerPixel = 0.000724;
   static const double lonPerPixel = 0.000909;
+  static const int defaultStrokeWidth = 2;
 
+  static const double strokeWidthToLatitude = 0.00000905;
+  static const double strokeWidthToLongitude = 0.0000113625;
   final int x;
   final int y;
   final int pixelId;
@@ -89,7 +92,7 @@ class Pixel extends Polygon {
               .withOpacity(0.3 + (Random().nextDouble() * (0.6 - 0.3)))
           : Colors.red.withOpacity(0.3 + (Random().nextDouble() * (0.6 - 0.3))),
       strokeColor: isMyPixel ? Color(0xFF0DF69E) : Colors.red,
-      strokeWidth: 2,
+      strokeWidth: defaultStrokeWidth,
       customOnTap: (int pixelId) async {
         FirebaseAnalytics.instance.logEvent(name: "individual_mode_pixel_click");
 
@@ -118,7 +121,7 @@ class Pixel extends Polygon {
       fillColor: Color(0xFF0DF69E)
           .withOpacity(0.3 + (Random().nextDouble() * (0.6 - 0.3))),
       strokeColor: Color(0xFF0DF69E),
-      strokeWidth: 2,
+      strokeWidth: defaultStrokeWidth,
       customOnTap: (int pixelId) async {
         FirebaseAnalytics.instance.logEvent(name: "history_pixel_click");
 
@@ -137,13 +140,13 @@ class Pixel extends Polygon {
 
   static List<LatLng> _getRectangleFromLatLng({required LatLng topLeftPoint}) {
     return List<LatLng>.of({
-      LatLng(topLeftPoint.latitude, topLeftPoint.longitude),
-      LatLng(topLeftPoint.latitude, topLeftPoint.longitude + lonPerPixel),
+      LatLng(topLeftPoint.latitude - strokeWidthToLatitude, topLeftPoint.longitude + strokeWidthToLongitude),
+      LatLng(topLeftPoint.latitude - strokeWidthToLatitude, topLeftPoint.longitude + lonPerPixel - strokeWidthToLongitude),
       LatLng(
-        topLeftPoint.latitude - latPerPixel,
-        topLeftPoint.longitude + lonPerPixel,
+        topLeftPoint.latitude - latPerPixel + strokeWidthToLatitude,
+        topLeftPoint.longitude + lonPerPixel - strokeWidthToLongitude,
       ),
-      LatLng(topLeftPoint.latitude - latPerPixel, topLeftPoint.longitude),
+      LatLng(topLeftPoint.latitude - latPerPixel + strokeWidthToLatitude, topLeftPoint.longitude + strokeWidthToLongitude),
     });
   }
 
@@ -157,7 +160,7 @@ class Pixel extends Polygon {
       fillColor: Colors.white
           .withOpacity(0.3),
       strokeColor: Colors.white,
-      strokeWidth: 2,
+      strokeWidth: defaultStrokeWidth,
       customOnTap: (pixelId) {},
       zIndex: 1,
     );


### PR DESCRIPTION
## 작업 내용*
- 픽셀의 경계가 겹치는 문제 해결
## 고민한 내용*
- 우선 기본적인 접근 방법은 '픽셀의 크기를 경계의 굵기만큼 줄이는 것'이다.

- 현재 경계의 굵기는 2이며, 지도 화면에서의 기본 줌 레벨은 16.0이다.
- 이 상태에서 픽셀의 굵기가 약 2m정도일 것이라 추측하였고, 위경도로 계산해 실제로 픽셀을 해당 크기만큼 작게만드니 겹치는 문제가 사라졌다.

- 하지만, 화면을 축소 시 고정된 픽셀 크기로 인해 다시 겹치는 문제가 발생했다.
- 따라서 픽셀의 크기를 줌 레벨에 따라 동적으로 작게 만들어야 했다.
- 휴대폰 화면에 컴퓨터 싸인펜으로 직접 선을 그려 확인해보니, 줌 레벨 1 당 약 2배씩 확대/축소가 일어나는 것을 발견했다.
- 이를 활용해 dart의 pow 함수(지수 계산)를 사용해서 기본 줌 레벨 대비 얼마나 픽셀을 작게 만들어야 하는 지 결정했다.

## 작업 내용*
- 픽셀의 경계가 겹치는 문제 해결
## 고민한 내용*
- 우선 기본적인 접근 방법은 '픽셀의 크기를 경계의 굵기만큼 줄이는 것'이다.

- 현재 경계의 굵기는 2이며, 지도 화면에서의 기본 줌 레벨은 16.0이다.
- 이 상태에서 픽셀의 굵기가 약 2m정도일 것이라 추측하였고, 위경도로 계산해 실제로 픽셀을 해당 크기만큼 작게만드니 겹치는 문제가 사라졌다.

- 하지만, 화면을 축소 시 고정된 픽셀 크기로 인해 다시 겹치는 문제가 발생했다.
- 따라서 픽셀의 크기를 줌 레벨에 따라 동적으로 작게 만들어야 했다.
- 휴대폰 화면에 컴퓨터 싸인펜으로 직접 선을 그려 확인해보니, 줌 레벨 1 당 약 2배씩 확대/축소가 일어나는 것을 발견했다.
- 이를 활용해 dart의 pow 함수(지수 계산)를 사용해서 기본 줌 레벨 대비 얼마나 픽셀을 작게 만들어야 하는 지 결정했다.
- 
![image](https://github.com/user-attachments/assets/69ac41a2-bb57-4d59-924e-b5cbb7ba3faf) | ![image](https://github.com/user-attachments/assets/b210488a-fe3f-4191-be13-722d97b2c2af)
---|---|