### PR TITLE
M3-287 네트워크 알림 수정, 버전 업데이트 관리

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,8 +56,8 @@ android {
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 26
         targetSdkVersion flutter.targetSdkVersion
-        versionCode 5//flutterVersionCode.toInteger()
-        versionName "1.3"//flutterVersionName
+        versionCode 8//flutterVersionCode.toInteger()
+        versionName "1.0.3"//flutterVersionName
         multiDexEnabled true
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
 
     <application
         android:label="ground_flip"
@@ -53,6 +54,7 @@
             <meta-data
                 android:name="io.flutter.embedding.android.NormalTheme"
                 android:resource="@style/NormalTheme" />
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/lib/controllers/main_controller.dart
+++ b/lib/controllers/main_controller.dart
@@ -1,6 +1,7 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../constants/app_colors.dart';
@@ -12,6 +13,8 @@ import '../service/version_service.dart';
 class MainController extends GetxController {
   static const String playStoreUrl =
       'https://play.google.com/store/apps/details?id=com.m3pro.ground_flip';
+  static const String appStoreUrl =
+      "https://apps.apple.com/app/ground-flip/id6550922550";
   final FcmService fcmService = FcmService();
   final MyPlaceService myPlaceService = MyPlaceService();
   final VersionService versionService = VersionService();
@@ -27,14 +30,12 @@ class MainController extends GetxController {
   }
 
   Future<dynamic> checkVersion() async {
-    PackageInfo packageInfo = await PackageInfo.fromPlatform();
     VersionResponse versionResponse = await versionService.getVersion();
-    String currentVersion = packageInfo.version;
-    if (versionResponse.version != currentVersion) {
+    if (versionResponse.needUpdate == "NEED") {
       return Get.dialog(
         AlertDialog(
           title: Text(
-            "앱을 업데이트 해주세요!",
+            "앱의 최신버전이 존재합니다.",
             style: TextStyle(
               color: AppColors.textPrimary,
               fontSize: 20,
@@ -55,7 +56,11 @@ class MainController extends GetxController {
                     ),
                   ),
                   onPressed: () async {
-                    launchUrl(Uri.parse(playStoreUrl));
+                    if (Platform.isIOS) {
+                      launchUrl(Uri.parse(appStoreUrl));
+                    } else {
+                      launchUrl(Uri.parse(playStoreUrl));
+                    }
                   },
                 ),
               ),

--- a/lib/controllers/main_controller.dart
+++ b/lib/controllers/main_controller.dart
@@ -6,6 +6,8 @@ import '../service/my_place_service.dart';
 class MainController extends GetxController {
   final FcmService fcmService = FcmService();
   final MyPlaceService myPlaceService = MyPlaceService();
+  final RxBool internetCheck = true.obs;
+  final RxBool isAlertIsShow = false.obs;
 
   @override
   void onInit() async {
@@ -14,3 +16,4 @@ class MainController extends GetxController {
     myPlaceService.getMyPlaceInfo();
   }
 }
+

--- a/lib/controllers/main_controller.dart
+++ b/lib/controllers/main_controller.dart
@@ -10,7 +10,7 @@ import '../service/my_place_service.dart';
 import '../service/version_service.dart';
 
 class MainController extends GetxController {
-  static final String playStoreUrl =
+  static const String playStoreUrl =
       'https://play.google.com/store/apps/details?id=com.m3pro.ground_flip';
   final FcmService fcmService = FcmService();
   final MyPlaceService myPlaceService = MyPlaceService();

--- a/lib/controllers/main_controller.dart
+++ b/lib/controllers/main_controller.dart
@@ -2,10 +2,12 @@ import 'package:get/get.dart';
 
 import '../service/fcm_service.dart';
 import '../service/my_place_service.dart';
+import '../service/version_service.dart';
 
 class MainController extends GetxController {
   final FcmService fcmService = FcmService();
   final MyPlaceService myPlaceService = MyPlaceService();
+  final VersionService versionService = VersionService();
   final RxBool internetCheck = true.obs;
   final RxBool isAlertIsShow = false.obs;
 
@@ -14,6 +16,7 @@ class MainController extends GetxController {
     super.onInit();
     fcmService.registerFcmToken();
     myPlaceService.getMyPlaceInfo();
+    versionService.getVersion();
   }
 }
 

--- a/lib/controllers/main_controller.dart
+++ b/lib/controllers/main_controller.dart
@@ -1,13 +1,21 @@
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 
+import '../constants/app_colors.dart';
+import '../models/version_response.dart';
 import '../service/fcm_service.dart';
 import '../service/my_place_service.dart';
 import '../service/version_service.dart';
 
 class MainController extends GetxController {
+  static final String playStoreUrl =
+      'https://play.google.com/store/apps/details?id=com.m3pro.ground_flip';
   final FcmService fcmService = FcmService();
   final MyPlaceService myPlaceService = MyPlaceService();
   final VersionService versionService = VersionService();
+
   final RxBool internetCheck = true.obs;
   final RxBool isAlertIsShow = false.obs;
 
@@ -16,7 +24,51 @@ class MainController extends GetxController {
     super.onInit();
     fcmService.registerFcmToken();
     myPlaceService.getMyPlaceInfo();
-    versionService.getVersion();
+  }
+
+  Future<dynamic> checkVersion() async {
+    PackageInfo packageInfo = await PackageInfo.fromPlatform();
+    VersionResponse versionResponse = await versionService.getVersion();
+    String currentVersion = packageInfo.version;
+    if (versionResponse.version != currentVersion) {
+      return Get.dialog(
+        AlertDialog(
+          title: Text(
+            "앱을 업데이트 해주세요!",
+            style: TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 20,
+              fontWeight: FontWeight.w400,
+            ),
+          ),
+          actions: [
+            Align(
+              alignment: Alignment.bottomRight,
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 0),
+                child: TextButton(
+                  child: Text(
+                    '업데이트',
+                    style: TextStyle(
+                      color: AppColors.primary,
+                      fontSize: 17,
+                    ),
+                  ),
+                  onPressed: () async {
+                    launchUrl(Uri.parse(playStoreUrl));
+                  },
+                ),
+              ),
+            ),
+          ],
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          backgroundColor: AppColors.boxColor,
+        ),
+      );
+    } else {
+      return Container();
+    }
   }
 }
-

--- a/lib/controllers/setting_controller.dart
+++ b/lib/controllers/setting_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 import '../constants/text_styles.dart';
 import '../service/auth_service.dart';
@@ -8,6 +9,24 @@ import '../service/user_service.dart';
 class SettingController extends GetxController {
   final AuthService authService = AuthService();
   final UserService userService = UserService();
+  late PackageInfo packageInfo;
+  late String currentVersion;
+
+  @override
+  void onInit() {
+    init();
+    super.onInit();
+  }
+
+  Future<void> init() async{
+    await setPageInfo();
+    currentVersion = packageInfo.version;
+    update();
+  }
+
+  Future<void> setPageInfo() async{
+    packageInfo = await PackageInfo.fromPlatform();
+  }
 
   logout() async {
     _showLogoutDialog();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -89,6 +89,7 @@ class MyApp extends StatelessWidget {
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(textScaler: TextScaler.noScaling),
       child: GetMaterialApp(
+        debugShowCheckedModeBanner: false,
         navigatorObservers: [
           FirebaseAnalyticsObserver(analytics: analytics),
         ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,7 +53,7 @@ class MyApp extends StatelessWidget {
   final String initialRoute;
   static bool checkInternet = true;
 
-  var listener =
+  final listener =
       InternetConnection().onStatusChange.listen((InternetStatus status) {
     final MainController mainController = Get.find<MainController>();
     switch (status) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,18 +53,24 @@ class MyApp extends StatelessWidget {
   final String initialRoute;
   static bool checkInternet = true;
 
-  final listener =
+  var listener =
       InternetConnection().onStatusChange.listen((InternetStatus status) {
+    final MainController mainController = Get.find<MainController>();
     switch (status) {
       case InternetStatus.connected:
-        checkInternet = true;
+        mainController.internetCheck.value = true;
+        if (mainController.isAlertIsShow.value) {
+          Get.back();
+          mainController.isAlertIsShow.value = false;
+        }
         break;
       case InternetStatus.disconnected:
-        checkInternet = false;
+        mainController.internetCheck.value = false;
         Timer(
           Duration(seconds: 5),
           () {
-            if (!checkInternet) {
+            if (!mainController.internetCheck.value) {
+              mainController.isAlertIsShow.value = true;
               Get.dialog(
                 InternetDisconnect(),
               );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,11 +32,12 @@ Future<void> main() async {
   ]);
   await dotenv.load(fileName: ".env");
   await GetStorage.init();
-  MainController();
+  final MainController mainController = MainController();
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
+  mainController.checkVersion();
   KakaoSdk.init(nativeAppKey: dotenv.env['NATIVE_APP_KEY']!);
   LocationService().initBackgroundLocation();
   String initialRoute = await AuthService().isLogin() ? '/main' : '/permission';

--- a/lib/models/version_response.dart
+++ b/lib/models/version_response.dart
@@ -1,17 +1,16 @@
 
 class VersionResponse {
   String? version;
-  DateTime? createdDate;
+  String? needUpdate;
 
   VersionResponse({
     this.version,
-    this.createdDate,
+    this.needUpdate,
   });
 
   VersionResponse.fromJson(Map<String, dynamic> json){
     version = json['version'];
-    createdDate = json['createdDate'] != null ? DateTime.parse(json['createdDate']) : null;
+    needUpdate = json['needUpdate'];
   }
-
 
 }

--- a/lib/models/version_response.dart
+++ b/lib/models/version_response.dart
@@ -1,4 +1,3 @@
-import 'package:intl/intl.dart';
 
 class VersionResponse {
   String? version;

--- a/lib/models/version_response.dart
+++ b/lib/models/version_response.dart
@@ -1,0 +1,18 @@
+import 'package:intl/intl.dart';
+
+class VersionResponse {
+  String? version;
+  DateTime? createdDate;
+
+  VersionResponse({
+    this.version,
+    this.createdDate,
+  });
+
+  VersionResponse.fromJson(Map<String, dynamic> json){
+    version = json['version'];
+    createdDate = json['createdDate'] != null ? DateTime.parse(json['createdDate']) : null;
+  }
+
+
+}

--- a/lib/screens/my_place_screen.dart
+++ b/lib/screens/my_place_screen.dart
@@ -14,6 +14,24 @@ class MyPlaceScreen extends StatelessWidget {
     final MyPlaceController myPlaceController = Get.put(MyPlaceController());
 
     return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          onPressed: () {
+            Get.back();
+          },
+          icon: Icon(
+            Icons.arrow_back_ios,
+            color: AppColors.buttonColor,
+          ),
+        ),
+        backgroundColor: AppColors.background,
+        title: Text(
+          '내 장소 등록',
+          style: TextStyle(
+            color: AppColors.textPrimary,
+          ),
+        ),
+      ),
       body: Obx(() {
         if (myPlaceController.isLoading.value) {
           return const Center(
@@ -49,7 +67,7 @@ class MyPlaceScreen extends StatelessWidget {
                 },
               ),
               Positioned(
-                top: 60,
+                top: 20,
                 right: 10,
                 child: GestureDetector(
                   onTap: () {

--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
 import 'package:in_app_review/in_app_review.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../constants/app_colors.dart';
@@ -12,7 +11,6 @@ import '../controllers/setting_controller.dart';
 import '../widgets/common/app_bar.dart';
 import '../widgets/setting/setting_item.dart';
 import '../widgets/setting/setting_section.dart';
-import 'on_board_screen.dart';
 
 class SettingScreen extends StatelessWidget {
   static String individualInfoPolicyUrl =

--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -1,7 +1,10 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
 import 'package:in_app_review/in_app_review.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../constants/app_colors.dart';
@@ -20,6 +23,7 @@ class SettingScreen extends StatelessWidget {
       'https://autumn-blouse-355.notion.site/ab3799e4818249daa3bfc32c7f44089d?pvs=4';
   static String usageGuideUrl =
       'https://autumn-blouse-355.notion.site/e9414fa20bef4021b5e7193dd3e2e77d';
+  static String playGuideUrl = 'https://www.notion.so/e9414fa20bef4021b5e7193dd3e2e77d';
   static String customerSupportUrl = 'https://open.kakao.com/o/gH1dV7Eg';
   static String announcementUrl =
       'https://autumn-blouse-355.notion.site/009bea49570a42679153e9f48b010ffc?v=eea22d1fd25b42488a54cc1c49b7e216&pvs=4';
@@ -49,104 +53,113 @@ class SettingScreen extends StatelessWidget {
           ),
         ),
       ),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 10.0),
-        child: ListView(
-          children: [
-            SettingsSection(
-              items: [
-                SettingsItem(
-                  title: 'App Store 리뷰 남기기',
-                  onTap: () {
-                    final inAppReview = InAppReview.instance;
-                    inAppReview.openStoreListing(
-                      appStoreId: appStoreId,
-                    );
-                  },
-                  isLast: true,
-                ),
-              ],
-            ),
-            // SettingsSection(
-            //   title: '알림',
-            //   items: [
-            //     SettingsItem(title: '알림 설정'),
-            //     SettingsItem(title: '고객 문의 및 개선 요청', isLast: true),
-            //   ],
-            // ),
-            SettingsSection(
-              title: '가이드',
-              items: [
-                SettingsItem(
-                  title: '공지사항',
-                  onTap: () async {
-                    launchUrl(Uri.parse(announcementUrl));
-                  },
-                ),
-                SettingsItem(
-                  title: '사용 가이드',
-                  onTap: () {
-                    Get.to(() => OnBoardScreen());
-                  },
-                ),
-                SettingsItem(
-                  title: '고객 문의 및 개선 요청',
-                  isLast: true,
-                  onTap: () {
-                    launchUrl(Uri.parse(customerSupportUrl));
-                  },
-                ),
-              ],
-            ),
-            SettingsSection(
-              title: '기타',
-              items: [
-                SettingsItem(
-                  title: '서비스 이용약관',
-                  onTap: () {
-                    launchUrl(Uri.parse(individualInfoPolicyUrl));
-                  },
-                ),
-                SettingsItem(
-                  title: '위치기반서비스 이용약관',
-                  onTap: () {
-                    launchUrl(Uri.parse(serviceUsePolicyUrl));
-                  },
-                ),
-                SettingsItem(
-                  title: '개인정보 처리 방침',
-                  onTap: () {
-                    launchUrl(Uri.parse(placeServicePolicyUrl));
-                  },
-                ),
-                SettingsItem(
-                  title: '버전 정보',
-                  subTitle: "1.0.0",
-                  isLast: true,
-                ),
-              ],
-            ),
-            SettingsSection(
-              items: [
-                SettingsItem(
-                  title: '로그아웃',
-                  onTap: () {
-                    settingController.logout();
-                  },
-                ),
-                SettingsItem(
-                  title: '계정 탈퇴',
-                  isAccent: true,
-                  isLast: true,
-                  onTap: () {
-                    settingController.removeAccount();
-                  },
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
+      body: GetBuilder<SettingController>(builder: (controller) {
+        if (controller.currentVersion.isEmpty) {
+          return Center(
+            child: CircularProgressIndicator(),
+          );
+        }
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10.0),
+          child: ListView(
+            children: [
+              SettingsSection(
+                items: [
+                  SettingsItem(
+                    title: Platform.isIOS
+                        ? 'App Store 리뷰 남기기'
+                        : 'playstore 리뷰 남기기',
+                    onTap: () {
+                      final inAppReview = InAppReview.instance;
+                      inAppReview.openStoreListing(
+                        appStoreId: appStoreId,
+                      );
+                    },
+                    isLast: true,
+                  ),
+                ],
+              ),
+              // SettingsSection(
+              //   title: '알림',
+              //   items: [
+              //     SettingsItem(title: '알림 설정'),
+              //     SettingsItem(title: '고객 문의 및 개선 요청', isLast: true),
+              //   ],
+              // ),
+              SettingsSection(
+                title: '가이드',
+                items: [
+                  SettingsItem(
+                    title: '공지사항',
+                    onTap: () async {
+                      launchUrl(Uri.parse(announcementUrl));
+                    },
+                  ),
+                  SettingsItem(
+                    title: '사용 가이드',
+                    onTap: () {
+                      launchUrl(Uri.parse(playGuideUrl));
+                    },
+                  ),
+                  SettingsItem(
+                    title: '고객 문의 및 개선 요청',
+                    isLast: true,
+                    onTap: () {
+                      launchUrl(Uri.parse(customerSupportUrl));
+                    },
+                  ),
+                ],
+              ),
+              SettingsSection(
+                title: '기타',
+                items: [
+                  SettingsItem(
+                    title: '서비스 이용약관',
+                    onTap: () {
+                      launchUrl(Uri.parse(serviceUsePolicyUrl));
+                    },
+                  ),
+                  SettingsItem(
+                    title: '위치기반서비스 이용약관',
+                    onTap: () {
+                      launchUrl(Uri.parse(placeServicePolicyUrl));
+                    },
+                  ),
+                  SettingsItem(
+                    title: '개인정보 처리 방침',
+                    onTap: () {
+                      launchUrl(Uri.parse(individualInfoPolicyUrl));
+                    },
+                  ),
+                  SettingsItem(
+                    title: '버전 정보',
+                    subTitle: settingController.currentVersion,
+                    isLast: true,
+                  ),
+                ],
+              ),
+              SettingsSection(
+                items: [
+                  SettingsItem(
+                    title: '로그아웃',
+                    onTap: () {
+                      settingController.logout();
+                    },
+                  ),
+                  SettingsItem(
+                    title: '계정 탈퇴',
+                    isAccent: true,
+                    isLast: true,
+                    onTap: () {
+                      settingController.removeAccount();
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },),
     );
   }
 }

--- a/lib/service/version_service.dart
+++ b/lib/service/version_service.dart
@@ -1,0 +1,22 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+
+import '../models/version_response.dart';
+import '../utils/dio_service.dart';
+
+class VersionService {
+  static final VersionService _instance = VersionService._internal();
+
+  VersionService._internal();
+
+  factory VersionService() {
+    return _instance;
+  }
+
+  final Dio dio = DioService().getDio();
+
+  Future<VersionResponse> getVersion() async {
+    var response = await dio.get('/version');
+    return VersionResponse.fromJson(response.data['data']);
+  }
+}

--- a/lib/service/version_service.dart
+++ b/lib/service/version_service.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 import '../models/version_response.dart';
 import '../utils/dio_service.dart';
@@ -15,7 +16,11 @@ class VersionService {
   final Dio dio = DioService().getDio();
 
   Future<VersionResponse> getVersion() async {
-    var response = await dio.get('/version');
-    return VersionResponse.fromJson(response.data['data']);
+    PackageInfo packageInfo = await PackageInfo.fromPlatform();
+    String currentVersion = packageInfo.version;
+    var response = await dio.get('/version', queryParameters: {"currentVersion":currentVersion});
+    VersionResponse versionResponse = VersionResponse.fromJson(response.data['data']);
+    print('1111 ${versionResponse.needUpdate}');
+    return versionResponse;
   }
 }

--- a/lib/service/version_service.dart
+++ b/lib/service/version_service.dart
@@ -1,5 +1,4 @@
 import 'package:dio/dio.dart';
-import 'package:flutter/material.dart';
 
 import '../models/version_response.dart';
 import '../utils/dio_service.dart';

--- a/lib/service/version_service.dart
+++ b/lib/service/version_service.dart
@@ -20,7 +20,6 @@ class VersionService {
     String currentVersion = packageInfo.version;
     var response = await dio.get('/version', queryParameters: {"currentVersion":currentVersion});
     VersionResponse versionResponse = VersionResponse.fromJson(response.data['data']);
-    print('1111 ${versionResponse.needUpdate}');
     return versionResponse;
   }
 }

--- a/lib/widgets/map/my_place_bottom_sheet.dart
+++ b/lib/widgets/map/my_place_bottom_sheet.dart
@@ -36,7 +36,7 @@ class MyPlaceBottomSheet extends StatelessWidget {
               children: [
                 Expanded(
                   child: Text(
-                    "즐겨찾기 장소 등록",
+                    "내 장소 등록",
                     style: TextStyles.fs20w700cTextPrimary,
                   ),
                 ),

--- a/lib/widgets/map/my_place_bottom_sheet.dart
+++ b/lib/widgets/map/my_place_bottom_sheet.dart
@@ -5,6 +5,7 @@ import 'package:get_storage/get_storage.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
+import '../../controllers/map_controller.dart';
 import '../../controllers/my_place_controller.dart';
 import '../../service/my_place_service.dart';
 import 'place_change_toggle_button.dart';
@@ -17,6 +18,7 @@ class MyPlaceBottomSheet extends StatelessWidget {
 
   final MyPlaceService myPlaceService = MyPlaceService();
   final MyPlaceController myPlaceController = Get.find<MyPlaceController>();
+  final MapController mapController = Get.find<MapController>();
   final box = GetStorage();
 
   int selectedNumber = 0;
@@ -75,6 +77,7 @@ class MyPlaceBottomSheet extends StatelessWidget {
                       myPlaceController.myPlaceName.value,
                       myPlaceController.selectedLatitude.value,
                       myPlaceController.selectedLongitude.value,);
+                  mapController.myPlaceButtonVisible.value = false;
 
                   Get.back();
                   Get.back();

--- a/lib/widgets/map/my_place_button_icon.dart
+++ b/lib/widgets/map/my_place_button_icon.dart
@@ -33,7 +33,7 @@ class MyPlaceButtonIcon extends StatelessWidget {
             Get.dialog(
               AlertDialog(
                 title: Text(
-                  '등록을 삭제하시겠습니까?',
+                  '내 장소를 삭제하시겠습니까?',
                   style: TextStyle(
                     color: AppColors.textPrimary,
                     fontSize: 20,

--- a/lib/widgets/map/my_place_button_icon.dart
+++ b/lib/widgets/map/my_place_button_icon.dart
@@ -45,7 +45,7 @@ class MyPlaceButtonIcon extends StatelessWidget {
                     child: Text(
                       '확인',
                       style: TextStyle(
-                        color: AppColors.textSecondary,
+                        color: AppColors.primary,
                       ),
                     ),
                     onPressed: () async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -889,13 +889,13 @@ packages:
     source: hosted
     version: "0.5.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "4de6c36df77ffbcef0a5aefe04669d33f2d18397fea228277b852a2d4e58e860"
+      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.1"
+    version: "8.0.2"
   package_info_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   firebase_core: ^3.3.0
   firebase_analytics: ^11.2.1
   firebase_messaging: ^15.0.4
+  package_info_plus: ^8.0.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "GroundFlip"
 
 publish_to: 'none'
 
-version: 1.0.0+1
+version: 1.0.3+8
 
 environment:
   sdk: '>=3.3.4 <4.0.0'


### PR DESCRIPTION
## 작업 내용*
- 인터넷 끊김 알림 창이 인터넷이 다시 연결되면 자연스럽게 다시 내려가도록
- 내 장소 등록창 앱바 생성
- 버전 변경(1.0.3, 8)
- AD_ID 권한 생성

- 최신 버전을 받아와 앱의 현재 버전과 다를 시 업데이트 팝업 생성
## 고민한 내용*
- 사용자가 불편함을 느끼지 않게 하기 위해서 어떻게 해야할까
- 네트워크가 변동되면 동적으로 화면을 관리하기 위해 Getx 컨트롤러에서 관리
- 앱 버전을 체크하기 위해 package_info_plus 패키지 사용
- 앱의 현재 버전은 android배포시에는 android app build.gradle에서, 통합은 pubspec.yaml에서 관리한다
## 리뷰 요구사항
- 함수, 변수 이름
## 스크린샷
|   |   |
|---|---|
| ![image](https://github.com/user-attachments/assets/b472f150-fd57-430d-8cb8-547c0da1825d) | ![image](https://github.com/user-attachments/assets/650486e7-3bb4-469a-84d0-e7a240283224)
 |
