### PR TITLE
M3-303 걸음 수 전송 고치기 - 프론트엔드

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
 import 'package:get_storage/get_storage.dart';
-import 'package:ground_flip/service/alarm_service.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_common.dart';
 
@@ -21,6 +20,7 @@ import 'screens/permission_request_screen.dart';
 import 'screens/policy_screen.dart';
 import 'screens/setting_screen.dart';
 import 'screens/sign_up_screen.dart';
+import 'service/alarm_service.dart';
 import 'service/android_walking_service.dart';
 import 'service/auth_service.dart';
 import 'service/location_service.dart';

--- a/lib/service/alarm_service.dart
+++ b/lib/service/alarm_service.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:intl/intl.dart';
+
+import '../utils/android_notification.dart';
+import '../utils/secure_storage.dart';
+
+class AlarmService {
+  static initializeStepCount(String? title) async {
+    if (title != null && title.contains("걸음 수")) {
+      if (Platform.isAndroid) {
+        DateTime previousDay = DateTime.now().subtract(Duration(days: 1));
+
+        final SecureStorage secureStorage = SecureStorage();
+
+        String dailyStepKey = "STEP:${DateFormat('yyyy-MM-dd').format(previousDay)}";
+        String currentStepKey = "currentSteps";
+        if (!await secureStorage.secureStorage.containsKey(key: dailyStepKey)) {
+          await secureStorage.secureStorage.write(
+            key: dailyStepKey,
+            value: await secureStorage.secureStorage.read(key: currentStepKey),
+          );
+
+          await secureStorage.secureStorage.write(key: currentStepKey, value: '0');
+          AndroidWalkingHandler.currentSteps = 0;
+
+          FlutterForegroundTask.updateService(
+            notificationTitle: "걸음수",
+            notificationText: 0.toString(),
+          );
+        }
+      }
+    }
+  }
+}

--- a/lib/service/android_walking_service.dart
+++ b/lib/service/android_walking_service.dart
@@ -62,6 +62,17 @@ class AndroidWalkingService implements WalkingService {
     );
   }
 
+  Future<void> postAllUserStepFromStorage() async {
+    Map<String, int> allSteps = await _getStepData();
+
+    allSteps.forEach((date, steps) async {
+      await dio.post(
+        '/steps',
+        data: {"userId": UserManager().getUserId(), "date": date, "steps": steps},
+      );
+    });
+  }
+
   Future<void> _initForegroundWalkingTask() async {
     initForegroundTask();
   }
@@ -72,9 +83,8 @@ class AndroidWalkingService implements WalkingService {
     Map<String, int> stepData = {};
     allSteps.forEach((key, value) async {
       if (key.startsWith("STEP:")) {
-        String dateKey = key.substring(5); // This removes "STEP:"
+        String dateKey = key.substring(5);
         stepData[dateKey] = int.parse(value);
-
         await secureStorage.delete(key: key);
       }
     });

--- a/lib/service/android_walking_service.dart
+++ b/lib/service/android_walking_service.dart
@@ -65,4 +65,20 @@ class AndroidWalkingService implements WalkingService {
   Future<void> _initForegroundWalkingTask() async {
     initForegroundTask();
   }
+
+  Future<Map<String, int>> _getStepData() async {
+    Map<String, String> allSteps = await secureStorage.readAll();
+
+    Map<String, int> stepData = {};
+    allSteps.forEach((key, value) async {
+      if (key.startsWith("STEP:")) {
+        String dateKey = key.substring(5); // This removes "STEP:"
+        stepData[dateKey] = int.parse(value);
+
+        await secureStorage.delete(key: key);
+      }
+    });
+
+    return stepData;
+  }
 }

--- a/lib/utils/android_notification.dart
+++ b/lib/utils/android_notification.dart
@@ -62,7 +62,7 @@ class AndroidWalkingHandler extends TaskHandler {
   static String todayStepKey = 'currentSteps';
   static String lastSavedStepKey = 'lastSteps';
   Timer? _midnightTimer;
-  int currentSteps = 0;
+  static int currentSteps = 0;
 
   @override
   void onStart(DateTime timestamp, SendPort? sendPort) async {
@@ -90,15 +90,15 @@ class AndroidWalkingHandler extends TaskHandler {
     Duration timeUntilMidnight = midnight.difference(now);
     _midnightTimer?.cancel();
     _midnightTimer = Timer(timeUntilMidnight, () {
-      _resetStepsAtMidnight();
+      resetStepsAtMidnight();
       _midnightTimer?.cancel();
       _midnightTimer = Timer.periodic(Duration(days: 1), (timer) {
-        _resetStepsAtMidnight();
+        resetStepsAtMidnight();
       });
     });
   }
 
-  void _resetStepsAtMidnight() async {
+  void resetStepsAtMidnight() async {
     String token = await secureStorage.readAccessToken();
     int userId = authService.extractUserIdFromToken(token);
     DateTime previousDay = DateTime.now().subtract(Duration(days: 1));

--- a/lib/utils/android_notification.dart
+++ b/lib/utils/android_notification.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 import 'dart:isolate';
-import 'dart:math';
 
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:pedometer/pedometer.dart';
 
 import '../service/android_walking_service.dart';
-import '../service/auth_service.dart';
 import 'secure_storage.dart';
 
 Future<void> initForegroundTask() async {


### PR DESCRIPTION
## 작업 내용*
- 자정에 제목에 '걸음 수'를 포함하는 알림을 수신하면 걸음 수를 초기화하고 
- 로컬 스토리지에 저장하는 기능 구현
- 기존 android_notification에서 걸음 수 초기화 로직 제거
## 고민한 내용*
- 처음엔 자정에 알림을 수신하면 서버에 http 요청을 보내려 했다.
- 하지만 백그라운드 시 객체를 의존 받을 수 없는 문제가 존재했다.
- 따라서 우선, "STEP:{어제 날짜}"를 key로, 걸음 수를 value로 스토리지에 저장한다.
- 그리고 이후 앱이 켜지면 이들을 읽어 http로 전송한다.
