### PR TITLE
M3 295 알림 권한 동의 페이지 구현

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		4EB854D129889EE1A9F5CBAF /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 239794E191ECC31390795268 /* Pods_Runner.framework */; };
-		6F8097AE2C64F082004A75E9 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 6F8097AD2C64F082004A75E9 /* PrivacyInfo.xcprivacy */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };

--- a/lib/controllers/setting_controller.dart
+++ b/lib/controllers/setting_controller.dart
@@ -7,6 +7,7 @@ import '../models/permission.dart';
 import '../service/auth_service.dart';
 import '../service/permission_service.dart';
 import '../service/user_service.dart';
+import '../widgets/common/alert.dart';
 
 class SettingController extends GetxController {
   final AuthService authService = AuthService();
@@ -36,13 +37,21 @@ class SettingController extends GetxController {
 
   changeServiceNotificationStatus() async {
     bool changedStatus = !isServiceNotificationEnabled.value;
-    await permissionService.updateServiceNotification(changedStatus);
-    isServiceNotificationEnabled.value = changedStatus;
+    try {
+      await permissionService.updateServiceNotification(changedStatus);
+      isServiceNotificationEnabled.value = changedStatus;
+    } catch (e) {
+      Get.dialog(Alert(title: "실패", content: "다시 시도 해주세요!", buttonText: "확인"));
+    }
   }
 
   changeMarketingNotificationStatus() async {
     bool changedStatus = !isMarketingNotificationEnabled.value;
-    await permissionService.updateMarketingNotification(changedStatus);
+    try {
+      await permissionService.updateMarketingNotification(changedStatus);
+    } catch (e) {
+      Get.dialog(Alert(title: "실패", content: "다시 시도 해주세요!", buttonText: "확인"));
+    }
     isMarketingNotificationEnabled.value = changedStatus;
   }
 

--- a/lib/controllers/setting_controller.dart
+++ b/lib/controllers/setting_controller.dart
@@ -2,12 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
+import '../constants/app_colors.dart';
 import '../constants/text_styles.dart';
 import '../models/permission.dart';
 import '../service/auth_service.dart';
 import '../service/permission_service.dart';
 import '../service/user_service.dart';
-import '../widgets/common/alert.dart';
+import '../widgets/common/alert/alert.dart';
 
 class SettingController extends GetxController {
   final AuthService authService = AuthService();
@@ -70,7 +71,14 @@ class SettingController extends GetxController {
   void _showLogoutDialog() {
     Get.dialog(
       AlertDialog(
-        title: Text('로그아웃 하시겠습니까?'),
+        title: Text(
+          '로그아웃 하시겠습니까?',
+          style: TextStyle(
+            color: AppColors.textPrimary,
+            fontSize: 20,
+            fontWeight: FontWeight.w400,
+          ),
+        ),
         actions: [
           TextButton(
             child: Text('아니오', style: TextStyles.fs17w600cAccent),
@@ -79,13 +87,17 @@ class SettingController extends GetxController {
             },
           ),
           TextButton(
-            child: Text('예', style: TextStyles.fs17w600cTextBlack),
+            child: Text('예', style: TextStyles.fs17w700cPrimary),
             onPressed: () async {
               await authService.logout();
               Get.offAllNamed('/login');
             },
           ),
         ],
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        backgroundColor: AppColors.boxColor,
       ),
     );
   }
@@ -93,8 +105,18 @@ class SettingController extends GetxController {
   void _showRemoveAccountDialog() {
     Get.dialog(
       AlertDialog(
-        title: Text('정말 탈퇴 하시겠습니까?'),
-        content: Text('탈퇴 시 모든 정보가 즉시 삭제되며, 복구 할 수 없습니다.'),
+        title: Text(
+          '정말 탈퇴 하시겠습니까?',
+          style: TextStyle(
+            color: AppColors.textPrimary,
+            fontSize: 20,
+            fontWeight: FontWeight.w400,
+          ),
+        ),
+        content: Text(
+          '탈퇴 시 모든 정보가 즉시 삭제되며, 복구 할 수 없습니다.',
+          style: TextStyles.fs17w400cTextSecondary,
+        ),
         actions: [
           TextButton(
             child: Text('아니오', style: TextStyles.fs17w600cAccent),
@@ -103,7 +125,7 @@ class SettingController extends GetxController {
             },
           ),
           TextButton(
-            child: Text('예', style: TextStyles.fs17w600cTextBlack),
+            child: Text('예', style: TextStyles.fs17w700cPrimary),
             onPressed: () async {
               try {
                 Get.back();
@@ -115,6 +137,10 @@ class SettingController extends GetxController {
             },
           ),
         ],
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        backgroundColor: AppColors.boxColor,
       ),
     );
   }
@@ -122,8 +148,18 @@ class SettingController extends GetxController {
   void _showFailDialog() {
     Get.dialog(
       AlertDialog(
-        title: Text('실패하였습니다.'),
-        content: Text('잠시후 다시 시도해주세요.'),
+        title: Text(
+          '실패하였습니다.',
+          style: TextStyle(
+            color: AppColors.textPrimary,
+            fontSize: 20,
+            fontWeight: FontWeight.w400,
+          ),
+        ),
+        content: Text(
+          '잠시후 다시 시도해주세요.',
+          style: TextStyles.fs17w400cTextSecondary,
+        ),
         actions: [
           TextButton(
             child: Text('닫기', style: TextStyles.fs17w600cAccent),
@@ -132,6 +168,10 @@ class SettingController extends GetxController {
             },
           ),
         ],
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        backgroundColor: AppColors.boxColor,
       ),
     );
   }

--- a/lib/controllers/setting_controller.dart
+++ b/lib/controllers/setting_controller.dart
@@ -3,14 +3,20 @@ import 'package:get/get.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../constants/text_styles.dart';
+import '../models/permission.dart';
 import '../service/auth_service.dart';
+import '../service/permission_service.dart';
 import '../service/user_service.dart';
 
 class SettingController extends GetxController {
   final AuthService authService = AuthService();
   final UserService userService = UserService();
+  final PermissionService permissionService = PermissionService();
   late PackageInfo packageInfo;
+
   late String currentVersion;
+  late RxBool isServiceNotificationEnabled;
+  late RxBool isMarketingNotificationEnabled;
 
   @override
   void onInit() {
@@ -18,13 +24,17 @@ class SettingController extends GetxController {
     super.onInit();
   }
 
-  Future<void> init() async{
+  Future<void> init() async {
     await setPageInfo();
+    Permission permission = await permissionService.getPermission();
     currentVersion = packageInfo.version;
     update();
+    isServiceNotificationEnabled = permission.isServiceNotificationEnabled.obs;
+    isMarketingNotificationEnabled =
+        permission.isMarketingNotificationEnabled.obs;
   }
 
-  Future<void> setPageInfo() async{
+  Future<void> setPageInfo() async {
     packageInfo = await PackageInfo.fromPlatform();
   }
 

--- a/lib/controllers/setting_controller.dart
+++ b/lib/controllers/setting_controller.dart
@@ -34,6 +34,18 @@ class SettingController extends GetxController {
         permission.isMarketingNotificationEnabled.obs;
   }
 
+  changeServiceNotificationStatus() async {
+    bool changedStatus = !isServiceNotificationEnabled.value;
+    await permissionService.updateServiceNotification(changedStatus);
+    isServiceNotificationEnabled.value = changedStatus;
+  }
+
+  changeMarketingNotificationStatus() async {
+    bool changedStatus = !isMarketingNotificationEnabled.value;
+    await permissionService.updateMarketingNotification(changedStatus);
+    isMarketingNotificationEnabled.value = changedStatus;
+  }
+
   Future<void> setPageInfo() async {
     packageInfo = await PackageInfo.fromPlatform();
   }

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -68,11 +68,11 @@ class SignUpController extends GetxController {
       imageSize = await selectedImage.length();
       imageSizeMB = imageSize / (1024 * 1024);
       if (imageSizeMB > 10) {
-        if(context.mounted){
+        if (context.mounted) {
           showDialog(
             context: context,
             builder: (BuildContext context) {
-              return Alert(text1: "10MB 이하 사이즈의 이미지를 넣어주세요!", text2: "확인");
+              return Alert(title: "10MB 이하 사이즈의 이미지를 넣어주세요!", buttonText: "확인");
             },
           );
         }

--- a/lib/controllers/sign_up_controller.dart
+++ b/lib/controllers/sign_up_controller.dart
@@ -7,7 +7,7 @@ import 'package:image_picker/image_picker.dart';
 import '../constants/app_colors.dart';
 import '../service/user_service.dart';
 import '../utils/secure_storage.dart';
-import '../widgets/common/alert.dart';
+import '../widgets/common/alert/alert.dart';
 
 class SignUpController extends GetxController {
   final FirebaseAnalytics analytics = FirebaseAnalytics.instance;

--- a/lib/controllers/user_info_controller.dart
+++ b/lib/controllers/user_info_controller.dart
@@ -47,12 +47,12 @@ class UserInfoController extends GetxController {
   }
 
   @override
-  Future<void> onClose() async{
+  Future<void> onClose() async {
     await textDispose();
     super.onClose();
   }
 
-  Future<void> textDispose() async{
+  Future<void> textDispose() async {
     textEditingController.dispose();
     textFocusNode.dispose();
   }
@@ -133,11 +133,11 @@ class UserInfoController extends GetxController {
       imageSize = await selectedImage.length();
       imageSizeMB = imageSize / (1024 * 1024);
       if (imageSizeMB > 10) {
-        if(context.mounted){
+        if (context.mounted) {
           showDialog(
             context: context,
             builder: (BuildContext context) {
-              return Alert(text1: "10MB 이하 사이즈의 이미지를 넣어주세요!", text2: "확인");
+              return Alert(title: "10MB 이하 사이즈의 이미지를 넣어주세요!", buttonText: "확인");
             },
           );
         }

--- a/lib/controllers/user_info_controller.dart
+++ b/lib/controllers/user_info_controller.dart
@@ -6,7 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import '../constants/app_colors.dart';
 import '../models/user.dart';
 import '../service/user_service.dart';
-import '../widgets/common/alert.dart';
+import '../widgets/common/alert/alert.dart';
 import 'my_page_controller.dart';
 
 class UserInfoController extends GetxController {

--- a/lib/models/permission.dart
+++ b/lib/models/permission.dart
@@ -1,0 +1,23 @@
+class Permission {
+  final bool isServiceNotificationEnabled;
+  final bool isMarketingNotificationEnabled;
+
+  Permission({
+    required this.isServiceNotificationEnabled,
+    required this.isMarketingNotificationEnabled,
+  });
+
+  factory Permission.fromJson(Map<String, dynamic> json) {
+    return switch (json) {
+      {
+        'isServiceNotificationEnabled': var isServiceNotificationEnabled,
+        'isMarketingNotificationEnabled': var isMarketingNotificationEnabled,
+      } =>
+        Permission(
+          isServiceNotificationEnabled: isServiceNotificationEnabled,
+          isMarketingNotificationEnabled: isMarketingNotificationEnabled,
+        ),
+      _ => throw const FormatException('Failed to load Permission')
+    };
+  }
+}

--- a/lib/models/permission.dart
+++ b/lib/models/permission.dart
@@ -10,8 +10,8 @@ class Permission {
   factory Permission.fromJson(Map<String, dynamic> json) {
     return switch (json) {
       {
-        'isServiceNotificationEnabled': var isServiceNotificationEnabled,
-        'isMarketingNotificationEnabled': var isMarketingNotificationEnabled,
+        'serviceNotificationEnabled': var isServiceNotificationEnabled,
+        'marketingNotificationEnabled': var isMarketingNotificationEnabled,
       } =>
         Permission(
           isServiceNotificationEnabled: isServiceNotificationEnabled,

--- a/lib/screens/permission_request_screen.dart
+++ b/lib/screens/permission_request_screen.dart
@@ -66,7 +66,8 @@ class PermissionRequestScreen extends StatelessWidget {
                       iconPath:
                           'assets/images/permission/notification_icon.png',
                       permissionName: '알림',
-                      permissionDescription: '걸음 수를 알림창에 표시하기 위해 필요해요!',
+                      permissionDescription:
+                          '공지사항, 앱 내의 활동에 대한 알림을 수신하기하고 걸음 수를 알림창에 표시하기 위해 필요해요!',
                     ),
                     SizedBox(
                       height: 16.0,

--- a/lib/screens/policy_screen.dart
+++ b/lib/screens/policy_screen.dart
@@ -4,9 +4,9 @@ import 'package:get/get.dart';
 import '../constants/app_colors.dart';
 import '../constants/text_styles.dart';
 import '../controllers/policy_controller.dart';
+import '../widgets/permission/marketing_push_permission_alert.dart';
 import '../widgets/policy/check_policy.dart';
 import '../widgets/policy/policy_all_check.dart';
-import 'sign_up_screen.dart';
 
 class PolicyScreen extends StatelessWidget {
   const PolicyScreen({super.key});
@@ -65,7 +65,7 @@ class PolicyScreen extends StatelessWidget {
                   borderRadius: BorderRadius.circular(16),
                   onTap: () {
                     policyController.allPolicyChecked.value == 1
-                        ? Get.to(() => SignUpScreen())
+                        ? Get.dialog(MarketingPushPermissionAlert())
                         : null;
                   },
                   child: Container(

--- a/lib/screens/policy_screen.dart
+++ b/lib/screens/policy_screen.dart
@@ -4,7 +4,7 @@ import 'package:get/get.dart';
 import '../constants/app_colors.dart';
 import '../constants/text_styles.dart';
 import '../controllers/policy_controller.dart';
-import '../widgets/permission/marketing_push_permission_alert.dart';
+import '../widgets/common/alert/marketing_push_permission_alert.dart';
 import '../widgets/policy/check_policy.dart';
 import '../widgets/policy/policy_all_check.dart';
 

--- a/lib/screens/push_setting_screen.dart
+++ b/lib/screens/push_setting_screen.dart
@@ -39,11 +39,13 @@ class PushSettingScreen extends StatelessWidget {
               title: '서비스 알림',
               subTitle: "매일 아침 동기 부여 알림을 받습니다.",
               isEnabled: settingController.isServiceNotificationEnabled,
+              onChanged: settingController.changeServiceNotificationStatus,
             ),
             PushPermissionItem(
               title: '마케팅 알림',
               subTitle: "앱의 이벤트, 소식, 해택 등을 알림을 받습니다.",
               isEnabled: settingController.isMarketingNotificationEnabled,
+              onChanged: settingController.changeMarketingNotificationStatus,
               isLast: true,
             ),
           ],

--- a/lib/screens/push_setting_screen.dart
+++ b/lib/screens/push_setting_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../constants/app_colors.dart';
+import '../controllers/setting_controller.dart';
 import '../widgets/common/app_bar.dart';
 import '../widgets/setting/push_permission_item.dart';
 import '../widgets/setting/setting_section.dart';
@@ -11,6 +12,8 @@ class PushSettingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final SettingController settingController = Get.find<SettingController>();
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: AppColors.background,
@@ -35,10 +38,12 @@ class PushSettingScreen extends StatelessWidget {
             PushPermissionItem(
               title: '서비스 알림',
               subTitle: "매일 아침 동기 부여 알림을 받습니다.",
+              isEnabled: settingController.isServiceNotificationEnabled,
             ),
             PushPermissionItem(
               title: '마케팅 알림',
               subTitle: "앱의 이벤트, 소식, 해택 등을 알림을 받습니다.",
+              isEnabled: settingController.isMarketingNotificationEnabled,
               isLast: true,
             ),
           ],

--- a/lib/screens/push_setting_screen.dart
+++ b/lib/screens/push_setting_screen.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../constants/app_colors.dart';
+import '../widgets/common/app_bar.dart';
+import '../widgets/setting/push_permission_item.dart';
+import '../widgets/setting/setting_section.dart';
+
+class PushSettingScreen extends StatelessWidget {
+  const PushSettingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        leading: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10.0),
+          child: IconButton(
+            icon: Icon(Icons.arrow_back_ios, color: Colors.white),
+            onPressed: () {
+              Get.back();
+            },
+          ),
+        ),
+        title: AppBarTitle(
+          title: "알림 설정",
+        ),
+      ),
+      backgroundColor: AppColors.background,
+      body: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 10),
+        child: SettingsSection(
+          items: [
+            PushPermissionItem(
+              title: '서비스 알림',
+              subTitle: "매일 아침 동기 부여 알림을 받습니다.",
+            ),
+            PushPermissionItem(
+              title: '마케팅 알림',
+              subTitle: "앱의 이벤트, 소식, 해택 등을 알림을 받습니다.",
+              isLast: true,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
-import 'package:ground_flip/screens/push_setting_screen.dart';
 import 'package:in_app_review/in_app_review.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -12,6 +11,7 @@ import '../controllers/setting_controller.dart';
 import '../widgets/common/app_bar.dart';
 import '../widgets/setting/setting_item.dart';
 import '../widgets/setting/setting_section.dart';
+import 'push_setting_screen.dart';
 
 class SettingScreen extends StatelessWidget {
   static String individualInfoPolicyUrl =

--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -53,113 +53,104 @@ class SettingScreen extends StatelessWidget {
           ),
         ),
       ),
-      body: GetBuilder<SettingController>(
-        builder: (controller) {
-          if (controller.currentVersion.isEmpty) {
-            return Center(
-              child: CircularProgressIndicator(),
-            );
-          }
-          return Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 10.0),
-            child: ListView(
-              children: [
-                SettingsSection(
-                  items: [
-                    SettingsItem(
-                      title: '알림 설정',
-                      onTap: () {
-                        Get.to(PushSettingScreen());
-                      },
-                    ),
-                    SettingsItem(
-                      title: Platform.isIOS
-                          ? 'App Store 리뷰 남기기'
-                          : 'playstore 리뷰 남기기',
-                      onTap: () {
-                        final inAppReview = InAppReview.instance;
-                        inAppReview.openStoreListing(
-                          appStoreId: appStoreId,
-                        );
-                      },
-                      isLast: true,
-                    ),
-                  ],
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10.0),
+        child: ListView(
+          children: [
+            SettingsSection(
+              items: [
+                SettingsItem(
+                  title: '알림 설정',
+                  onTap: () {
+                    Get.to(PushSettingScreen());
+                  },
                 ),
-                SettingsSection(
-                  title: '가이드',
-                  items: [
-                    SettingsItem(
-                      title: '공지사항',
-                      onTap: () async {
-                        launchUrl(Uri.parse(announcementUrl));
-                      },
-                    ),
-                    SettingsItem(
-                      title: '사용 가이드',
-                      onTap: () {
-                        launchUrl(Uri.parse(playGuideUrl));
-                      },
-                    ),
-                    SettingsItem(
-                      title: '고객 문의 및 개선 요청',
-                      isLast: true,
-                      onTap: () {
-                        launchUrl(Uri.parse(customerSupportUrl));
-                      },
-                    ),
-                  ],
-                ),
-                SettingsSection(
-                  title: '기타',
-                  items: [
-                    SettingsItem(
-                      title: '서비스 이용약관',
-                      onTap: () {
-                        launchUrl(Uri.parse(serviceUsePolicyUrl));
-                      },
-                    ),
-                    SettingsItem(
-                      title: '위치기반서비스 이용약관',
-                      onTap: () {
-                        launchUrl(Uri.parse(placeServicePolicyUrl));
-                      },
-                    ),
-                    SettingsItem(
-                      title: '개인정보 처리 방침',
-                      onTap: () {
-                        launchUrl(Uri.parse(individualInfoPolicyUrl));
-                      },
-                    ),
-                    SettingsItem(
-                      title: '버전 정보',
-                      subTitle: settingController.currentVersion,
-                      isLast: true,
-                    ),
-                  ],
-                ),
-                SettingsSection(
-                  items: [
-                    SettingsItem(
-                      title: '로그아웃',
-                      onTap: () {
-                        settingController.logout();
-                      },
-                    ),
-                    SettingsItem(
-                      title: '계정 탈퇴',
-                      isAccent: true,
-                      isLast: true,
-                      onTap: () {
-                        settingController.removeAccount();
-                      },
-                    ),
-                  ],
+                SettingsItem(
+                  title:
+                      Platform.isIOS ? 'App Store 리뷰 남기기' : 'playstore 리뷰 남기기',
+                  onTap: () {
+                    final inAppReview = InAppReview.instance;
+                    inAppReview.openStoreListing(
+                      appStoreId: appStoreId,
+                    );
+                  },
+                  isLast: true,
                 ),
               ],
             ),
-          );
-        },
+            SettingsSection(
+              title: '가이드',
+              items: [
+                SettingsItem(
+                  title: '공지사항',
+                  onTap: () async {
+                    launchUrl(Uri.parse(announcementUrl));
+                  },
+                ),
+                SettingsItem(
+                  title: '사용 가이드',
+                  onTap: () {
+                    launchUrl(Uri.parse(playGuideUrl));
+                  },
+                ),
+                SettingsItem(
+                  title: '고객 문의 및 개선 요청',
+                  isLast: true,
+                  onTap: () {
+                    launchUrl(Uri.parse(customerSupportUrl));
+                  },
+                ),
+              ],
+            ),
+            SettingsSection(
+              title: '기타',
+              items: [
+                SettingsItem(
+                  title: '서비스 이용약관',
+                  onTap: () {
+                    launchUrl(Uri.parse(serviceUsePolicyUrl));
+                  },
+                ),
+                SettingsItem(
+                  title: '위치기반서비스 이용약관',
+                  onTap: () {
+                    launchUrl(Uri.parse(placeServicePolicyUrl));
+                  },
+                ),
+                SettingsItem(
+                  title: '개인정보 처리 방침',
+                  onTap: () {
+                    launchUrl(Uri.parse(individualInfoPolicyUrl));
+                  },
+                ),
+                SettingsItem(
+                  title: '버전 정보',
+                  // subTitle: settingController.currentVersion,
+                  subTitle: "1.0.3",
+                  isLast: true,
+                ),
+              ],
+            ),
+            SettingsSection(
+              items: [
+                SettingsItem(
+                  title: '로그아웃',
+                  onTap: () {
+                    settingController.logout();
+                  },
+                ),
+                SettingsItem(
+                  title: '계정 탈퇴',
+                  isAccent: true,
+                  isLast: true,
+                  onTap: () {
+                    settingController.removeAccount();
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
+import 'package:ground_flip/screens/push_setting_screen.dart';
 import 'package:in_app_review/in_app_review.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -21,7 +22,8 @@ class SettingScreen extends StatelessWidget {
       'https://autumn-blouse-355.notion.site/ab3799e4818249daa3bfc32c7f44089d?pvs=4';
   static String usageGuideUrl =
       'https://autumn-blouse-355.notion.site/e9414fa20bef4021b5e7193dd3e2e77d';
-  static String playGuideUrl = 'https://www.notion.so/e9414fa20bef4021b5e7193dd3e2e77d';
+  static String playGuideUrl =
+      'https://www.notion.so/e9414fa20bef4021b5e7193dd3e2e77d';
   static String customerSupportUrl = 'https://open.kakao.com/o/gH1dV7Eg';
   static String announcementUrl =
       'https://autumn-blouse-355.notion.site/009bea49570a42679153e9f48b010ffc?v=eea22d1fd25b42488a54cc1c49b7e216&pvs=4';
@@ -51,113 +53,114 @@ class SettingScreen extends StatelessWidget {
           ),
         ),
       ),
-      body: GetBuilder<SettingController>(builder: (controller) {
-        if (controller.currentVersion.isEmpty) {
-          return Center(
-            child: CircularProgressIndicator(),
+      body: GetBuilder<SettingController>(
+        builder: (controller) {
+          if (controller.currentVersion.isEmpty) {
+            return Center(
+              child: CircularProgressIndicator(),
+            );
+          }
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10.0),
+            child: ListView(
+              children: [
+                SettingsSection(
+                  items: [
+                    SettingsItem(
+                      title: '알림 설정',
+                      onTap: () {
+                        Get.to(PushSettingScreen());
+                      },
+                    ),
+                    SettingsItem(
+                      title: Platform.isIOS
+                          ? 'App Store 리뷰 남기기'
+                          : 'playstore 리뷰 남기기',
+                      onTap: () {
+                        final inAppReview = InAppReview.instance;
+                        inAppReview.openStoreListing(
+                          appStoreId: appStoreId,
+                        );
+                      },
+                      isLast: true,
+                    ),
+                  ],
+                ),
+                SettingsSection(
+                  title: '가이드',
+                  items: [
+                    SettingsItem(
+                      title: '공지사항',
+                      onTap: () async {
+                        launchUrl(Uri.parse(announcementUrl));
+                      },
+                    ),
+                    SettingsItem(
+                      title: '사용 가이드',
+                      onTap: () {
+                        launchUrl(Uri.parse(playGuideUrl));
+                      },
+                    ),
+                    SettingsItem(
+                      title: '고객 문의 및 개선 요청',
+                      isLast: true,
+                      onTap: () {
+                        launchUrl(Uri.parse(customerSupportUrl));
+                      },
+                    ),
+                  ],
+                ),
+                SettingsSection(
+                  title: '기타',
+                  items: [
+                    SettingsItem(
+                      title: '서비스 이용약관',
+                      onTap: () {
+                        launchUrl(Uri.parse(serviceUsePolicyUrl));
+                      },
+                    ),
+                    SettingsItem(
+                      title: '위치기반서비스 이용약관',
+                      onTap: () {
+                        launchUrl(Uri.parse(placeServicePolicyUrl));
+                      },
+                    ),
+                    SettingsItem(
+                      title: '개인정보 처리 방침',
+                      onTap: () {
+                        launchUrl(Uri.parse(individualInfoPolicyUrl));
+                      },
+                    ),
+                    SettingsItem(
+                      title: '버전 정보',
+                      subTitle: settingController.currentVersion,
+                      isLast: true,
+                    ),
+                  ],
+                ),
+                SettingsSection(
+                  items: [
+                    SettingsItem(
+                      title: '로그아웃',
+                      onTap: () {
+                        settingController.logout();
+                      },
+                    ),
+                    SettingsItem(
+                      title: '계정 탈퇴',
+                      isAccent: true,
+                      isLast: true,
+                      onTap: () {
+                        settingController.removeAccount();
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            ),
           );
-        }
-        return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 10.0),
-          child: ListView(
-            children: [
-              SettingsSection(
-                items: [
-                  SettingsItem(
-                    title: Platform.isIOS
-                        ? 'App Store 리뷰 남기기'
-                        : 'playstore 리뷰 남기기',
-                    onTap: () {
-                      final inAppReview = InAppReview.instance;
-                      inAppReview.openStoreListing(
-                        appStoreId: appStoreId,
-                      );
-                    },
-                    isLast: true,
-                  ),
-                ],
-              ),
-              // SettingsSection(
-              //   title: '알림',
-              //   items: [
-              //     SettingsItem(title: '알림 설정'),
-              //     SettingsItem(title: '고객 문의 및 개선 요청', isLast: true),
-              //   ],
-              // ),
-              SettingsSection(
-                title: '가이드',
-                items: [
-                  SettingsItem(
-                    title: '공지사항',
-                    onTap: () async {
-                      launchUrl(Uri.parse(announcementUrl));
-                    },
-                  ),
-                  SettingsItem(
-                    title: '사용 가이드',
-                    onTap: () {
-                      launchUrl(Uri.parse(playGuideUrl));
-                    },
-                  ),
-                  SettingsItem(
-                    title: '고객 문의 및 개선 요청',
-                    isLast: true,
-                    onTap: () {
-                      launchUrl(Uri.parse(customerSupportUrl));
-                    },
-                  ),
-                ],
-              ),
-              SettingsSection(
-                title: '기타',
-                items: [
-                  SettingsItem(
-                    title: '서비스 이용약관',
-                    onTap: () {
-                      launchUrl(Uri.parse(serviceUsePolicyUrl));
-                    },
-                  ),
-                  SettingsItem(
-                    title: '위치기반서비스 이용약관',
-                    onTap: () {
-                      launchUrl(Uri.parse(placeServicePolicyUrl));
-                    },
-                  ),
-                  SettingsItem(
-                    title: '개인정보 처리 방침',
-                    onTap: () {
-                      launchUrl(Uri.parse(individualInfoPolicyUrl));
-                    },
-                  ),
-                  SettingsItem(
-                    title: '버전 정보',
-                    subTitle: settingController.currentVersion,
-                    isLast: true,
-                  ),
-                ],
-              ),
-              SettingsSection(
-                items: [
-                  SettingsItem(
-                    title: '로그아웃',
-                    onTap: () {
-                      settingController.logout();
-                    },
-                  ),
-                  SettingsItem(
-                    title: '계정 탈퇴',
-                    isAccent: true,
-                    isLast: true,
-                    onTap: () {
-                      settingController.removeAccount();
-                    },
-                  ),
-                ],
-              ),
-            ],
-          ),
-        );
-      },),
+        },
+      ),
     );
   }
 }

--- a/lib/service/fcm_service.dart
+++ b/lib/service/fcm_service.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 
@@ -22,6 +24,7 @@ class FcmService {
       data: {
         "userId": UserManager().getUserId(),
         "fcmToken": fcmToken,
+        "device": Platform.isIOS ? "iOS" : "Android",
       },
     );
   }

--- a/lib/service/permission_service.dart
+++ b/lib/service/permission_service.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 
 import '../models/permission.dart';
 import '../utils/dio_service.dart';
+import '../utils/user_manager.dart';
 
 class PermissionService {
   static final PermissionService _instance = PermissionService._internal();
@@ -14,8 +15,31 @@ class PermissionService {
     return _instance;
   }
 
-  Future<Permission> getPermission(int userId) async {
+  Future<Permission> getPermission() async {
+    int? userId = UserManager().getUserId();
     var response = await dio.get('/permission/$userId');
     return Permission.fromJson(response.data['data']);
+  }
+
+  void updateServiceNotification(bool isEnabled) {
+    int? userId = UserManager().getUserId();
+    dio.put(
+      '/permission/service-notification',
+      data: {
+        "userId": userId,
+        "isEnabled": isEnabled,
+      },
+    );
+  }
+
+  void updateMarketingNotification(bool isEnabled) {
+    int? userId = UserManager().getUserId();
+    dio.put(
+      '/permission/marketing-notification',
+      data: {
+        "userId": userId,
+        "isEnabled": isEnabled,
+      },
+    );
   }
 }

--- a/lib/service/permission_service.dart
+++ b/lib/service/permission_service.dart
@@ -21,9 +21,9 @@ class PermissionService {
     return Permission.fromJson(response.data['data']);
   }
 
-  void updateServiceNotification(bool isEnabled) {
+  Future<void> updateServiceNotification(bool isEnabled) async {
     int? userId = UserManager().getUserId();
-    dio.put(
+    await dio.put(
       '/permission/service-notification',
       data: {
         "userId": userId,
@@ -32,9 +32,9 @@ class PermissionService {
     );
   }
 
-  void updateMarketingNotification(bool isEnabled) {
+  Future<void> updateMarketingNotification(bool isEnabled) async {
     int? userId = UserManager().getUserId();
-    dio.put(
+    await dio.put(
       '/permission/marketing-notification',
       data: {
         "userId": userId,

--- a/lib/service/permission_service.dart
+++ b/lib/service/permission_service.dart
@@ -1,0 +1,21 @@
+import 'package:dio/dio.dart';
+
+import '../models/permission.dart';
+import '../utils/dio_service.dart';
+
+class PermissionService {
+  static final PermissionService _instance = PermissionService._internal();
+
+  final Dio dio = DioService().getDio();
+
+  PermissionService._internal();
+
+  factory PermissionService() {
+    return _instance;
+  }
+
+  Future<Permission> getPermission(int userId) async {
+    var response = await dio.get('/permission/$userId');
+    return Permission.fromJson(response.data['data']);
+  }
+}

--- a/lib/widgets/common/alert.dart
+++ b/lib/widgets/common/alert.dart
@@ -2,41 +2,45 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../constants/app_colors.dart';
+import '../../constants/text_styles.dart';
 
 class Alert extends StatelessWidget {
-  final String text1;
-  final String text2;
-  Alert({super.key, required this.text1, required this.text2});
+  final String title;
+  String? content;
+  final String buttonText;
+
+  Alert(
+      {super.key, required this.title, required this.buttonText, this.content});
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
       title: Text(
-        text1,
+        title,
         style: TextStyle(
           color: AppColors.textPrimary,
           fontSize: 20,
           fontWeight: FontWeight.w400,
         ),
       ),
+      content: content == null
+          ? null
+          : Text(
+              content ?? "",
+              style: TextStyles.fs17w400cTextSecondary,
+            ),
       actions: [
-        Align(
-          alignment: Alignment.bottomRight,
-          child: Padding(
-            padding: EdgeInsets.symmetric(vertical: 0),
-            child: TextButton(
-              child: Text(
-                text2,
-                style: TextStyle(
-                  color: AppColors.primary,
-                  fontSize: 17,
-                ),
-              ),
-              onPressed: () {
-                Get.back();
-              },
+        TextButton(
+          child: Text(
+            buttonText,
+            style: TextStyle(
+              color: AppColors.primary,
+              fontSize: 17,
             ),
           ),
+          onPressed: () {
+            Get.back();
+          },
         ),
       ],
       shape: RoundedRectangleBorder(

--- a/lib/widgets/common/alert/alert.dart
+++ b/lib/widgets/common/alert/alert.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import '../../constants/app_colors.dart';
-import '../../constants/text_styles.dart';
+import '../../../constants/app_colors.dart';
+import '../../../constants/text_styles.dart';
 
 class Alert extends StatelessWidget {
   final String title;

--- a/lib/widgets/common/alert/alert.dart
+++ b/lib/widgets/common/alert/alert.dart
@@ -4,13 +4,18 @@ import 'package:get/get.dart';
 import '../../../constants/app_colors.dart';
 import '../../../constants/text_styles.dart';
 
+// ignore: must_be_immutable
 class Alert extends StatelessWidget {
   final String title;
   String? content;
   final String buttonText;
 
-  Alert(
-      {super.key, required this.title, required this.buttonText, this.content});
+  Alert({
+    super.key,
+    required this.title,
+    required this.buttonText,
+    this.content,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/common/alert/marketing_push_permission_alert.dart
+++ b/lib/widgets/common/alert/marketing_push_permission_alert.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:ground_flip/screens/sign_up_screen.dart';
 
-import '../../constants/app_colors.dart';
-import '../../constants/text_styles.dart';
-import '../../service/permission_service.dart';
+import '../../../constants/app_colors.dart';
+import '../../../constants/text_styles.dart';
+import '../../../service/permission_service.dart';
 
 class MarketingPushPermissionAlert extends StatelessWidget {
   MarketingPushPermissionAlert({super.key});

--- a/lib/widgets/common/alert/marketing_push_permission_alert.dart
+++ b/lib/widgets/common/alert/marketing_push_permission_alert.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:ground_flip/screens/sign_up_screen.dart';
 
 import '../../../constants/app_colors.dart';
 import '../../../constants/text_styles.dart';
+import '../../../screens/sign_up_screen.dart';
 import '../../../service/permission_service.dart';
 
 class MarketingPushPermissionAlert extends StatelessWidget {

--- a/lib/widgets/permission/marketing_push_permission_alert.dart
+++ b/lib/widgets/permission/marketing_push_permission_alert.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:ground_flip/screens/sign_up_screen.dart';
+
+import '../../constants/app_colors.dart';
+import '../../constants/text_styles.dart';
+import '../../service/permission_service.dart';
+
+class MarketingPushPermissionAlert extends StatelessWidget {
+  MarketingPushPermissionAlert({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(
+        "광고성 정보 수신 동의",
+        style: TextStyle(
+          color: AppColors.textPrimary,
+          fontSize: 20,
+          fontWeight: FontWeight.w400,
+        ),
+      ),
+      content: Text(
+        "푸시 알림을 통해 그라운드 플립의 이벤트, 소식, 해택 등을 전달해드리려고 합니다. \n\n앱 푸시에 동의하시겠습니까?",
+        style: TextStyles.fs17w400cTextSecondary,
+      ),
+      actions: [
+        TextButton(
+          child: Text(
+            "미동의",
+            style: TextStyle(
+              color: AppColors.accent,
+              fontSize: 17,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          onPressed: () {
+            Get.to(() => SignUpScreen());
+          },
+        ),
+        TextButton(
+          child: Text(
+            "동의",
+            style: TextStyle(
+              color: AppColors.primary,
+              fontSize: 17,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          onPressed: () {
+            PermissionService().updateMarketingNotification(true);
+            Get.to(() => SignUpScreen());
+          },
+        ),
+      ],
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      backgroundColor: AppColors.boxColor,
+    );
+  }
+}

--- a/lib/widgets/setting/push_permission_item.dart
+++ b/lib/widgets/setting/push_permission_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:get/get.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
@@ -7,6 +8,7 @@ class PushPermissionItem extends StatelessWidget {
   final String title;
   final String? subTitle;
   final bool isAccent;
+  final RxBool isEnabled;
   final bool isLast;
 
   PushPermissionItem({
@@ -14,6 +16,7 @@ class PushPermissionItem extends StatelessWidget {
     this.subTitle,
     this.isLast = false,
     this.isAccent = false,
+    required this.isEnabled,
     super.key,
   });
 
@@ -58,8 +61,12 @@ class PushPermissionItem extends StatelessWidget {
                 ],
               ),
             ),
-            // Spacer(),
-            CupertinoSwitch(value: true, onChanged: (bool value) {})
+            Obx(
+              () => CupertinoSwitch(
+                value: isEnabled.value,
+                onChanged: (bool value) {},
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/widgets/setting/push_permission_item.dart
+++ b/lib/widgets/setting/push_permission_item.dart
@@ -9,7 +9,7 @@ class PushPermissionItem extends StatelessWidget {
   final String? subTitle;
   final bool isAccent;
   final RxBool isEnabled;
-  final onChanged;
+  final Function onChanged;
   final bool isLast;
 
   PushPermissionItem({
@@ -19,7 +19,7 @@ class PushPermissionItem extends StatelessWidget {
     this.isAccent = false,
     required this.isEnabled,
     super.key,
-    this.onChanged,
+    required this.onChanged,
   });
 
   @override

--- a/lib/widgets/setting/push_permission_item.dart
+++ b/lib/widgets/setting/push_permission_item.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/cupertino.dart';
+
+import '../../constants/app_colors.dart';
+import '../../constants/text_styles.dart';
+
+class PushPermissionItem extends StatelessWidget {
+  final String title;
+  final String? subTitle;
+  final bool isAccent;
+  final bool isLast;
+
+  PushPermissionItem({
+    required this.title,
+    this.subTitle,
+    this.isLast = false,
+    this.isAccent = false,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20.0),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 20.0),
+        decoration: BoxDecoration(
+          border: Border(
+            bottom: isLast
+                ? BorderSide.none
+                : BorderSide(
+                    color: AppColors.backgroundThird,
+                    width: 1.0,
+                  ),
+          ),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: TextStyle(
+                      color:
+                          isAccent ? AppColors.accent : AppColors.textPrimary,
+                      fontSize: 17,
+                      fontWeight: FontWeight.w400,
+                    ),
+                  ),
+                  Text(
+                    subTitle!,
+                    style: TextStyles.fs14w400cTextSecondary,
+                    overflow: TextOverflow.visible,
+                  ),
+                ],
+              ),
+            ),
+            // Spacer(),
+            CupertinoSwitch(value: true, onChanged: (bool value) {})
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/setting/push_permission_item.dart
+++ b/lib/widgets/setting/push_permission_item.dart
@@ -9,6 +9,7 @@ class PushPermissionItem extends StatelessWidget {
   final String? subTitle;
   final bool isAccent;
   final RxBool isEnabled;
+  final onChanged;
   final bool isLast;
 
   PushPermissionItem({
@@ -18,6 +19,7 @@ class PushPermissionItem extends StatelessWidget {
     this.isAccent = false,
     required this.isEnabled,
     super.key,
+    this.onChanged,
   });
 
   @override
@@ -64,7 +66,9 @@ class PushPermissionItem extends StatelessWidget {
             Obx(
               () => CupertinoSwitch(
                 value: isEnabled.value,
-                onChanged: (bool value) {},
+                onChanged: (bool value) async {
+                  await onChanged();
+                },
               ),
             ),
           ],

--- a/lib/widgets/setting/setting_section.dart
+++ b/lib/widgets/setting/setting_section.dart
@@ -2,11 +2,10 @@ import 'package:flutter/material.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
-import 'setting_item.dart';
 
 class SettingsSection extends StatelessWidget {
   final String? title;
-  final List<SettingsItem> items;
+  final List<Widget> items;
 
   SettingsSection({this.title, required this.items, super.key});
 


### PR DESCRIPTION
## 작업 내용*
- 설정에 알림 동의 화면 구현
- 회원가입시 마케팅 동의 화면 구현
## 고민한 내용*
- 앱 최초 설치시 서비스 알림에 대한 동의 고지를 하여서 기본으로 서비스 알림은 동의 되게 만듬
## 리뷰 요구사항
- 리뷰할 때 중점적으로 봐줬으면 하는 내용들
## 스크린샷
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-21 at 15 49 47](https://github.com/user-attachments/assets/1ba81727-4854-4959-ac3a-dbd74acea1fc) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-21 at 15 50 12](https://github.com/user-attachments/assets/61f58b8f-737a-44f9-a0e8-4363295c9ee8) |
|----|----|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-21 at 15 50 15](https://github.com/user-attachments/assets/2acf7cb9-98a8-472c-94ea-734b2e24ef8f) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-21 at 15 56 56](https://github.com/user-attachments/assets/d1d000c2-65fe-498a-97e7-3123cb3b813d) |
|----|----|
