### PR TITLE
M3-340 그룹전 랭킹 기능 구현

### DIFF
--- a/lib/controllers/community_controller.dart
+++ b/lib/controllers/community_controller.dart
@@ -21,11 +21,11 @@ class CommunityController extends GetxController {
   final RxBool isLoading = true.obs;
 
   final RxList members = [
-    Ranking(userId: 1, rank: 1, currentPixelCount: 123, nickname: "test1"),
-    Ranking(userId: 1, rank: 2, currentPixelCount: 123, nickname: "test2"),
-    Ranking(userId: 1, rank: 3, currentPixelCount: 123, nickname: "test3"),
-    Ranking(userId: 1, rank: 4, currentPixelCount: 123, nickname: "test4"),
-    Ranking(userId: 1, rank: 5, currentPixelCount: 123, nickname: "test5"),
+    Ranking(id: 1, rank: 1, currentPixelCount: 123, name: "test1"),
+    Ranking(id: 1, rank: 2, currentPixelCount: 123, name: "test2"),
+    Ranking(id: 1, rank: 3, currentPixelCount: 123, name: "test3"),
+    Ranking(id: 1, rank: 4, currentPixelCount: 123, name: "test4"),
+    Ranking(id: 1, rank: 5, currentPixelCount: 123, name: "test5"),
   ].obs;
 
   init() async {

--- a/lib/controllers/community_info_controller.dart
+++ b/lib/controllers/community_info_controller.dart
@@ -20,11 +20,11 @@ class CommunityInfoController extends GetxController {
   final RxBool isLoading = true.obs;
 
   final RxList members = [
-    Ranking(userId: 1, rank: 1, currentPixelCount: 123, nickname: "test1"),
-    Ranking(userId: 1, rank: 2, currentPixelCount: 123, nickname: "test2"),
-    Ranking(userId: 1, rank: 3, currentPixelCount: 123, nickname: "test3"),
-    Ranking(userId: 1, rank: 4, currentPixelCount: 123, nickname: "test4"),
-    Ranking(userId: 1, rank: 5, currentPixelCount: 123, nickname: "test5"),
+    Ranking(id: 1, rank: 1, currentPixelCount: 123, name: "test1"),
+    Ranking(id: 1, rank: 2, currentPixelCount: 123, name: "test2"),
+    Ranking(id: 1, rank: 3, currentPixelCount: 123, name: "test3"),
+    Ranking(id: 1, rank: 4, currentPixelCount: 123, name: "test4"),
+    Ranking(id: 1, rank: 5, currentPixelCount: 123, name: "test5"),
   ].obs;
 
   init(int communityId) async {

--- a/lib/controllers/ranking_controller.dart
+++ b/lib/controllers/ranking_controller.dart
@@ -10,6 +10,7 @@ import '../service/user_service.dart';
 import '../utils/date_handler.dart';
 import '../utils/user_manager.dart';
 import '../widgets/ranking/ranking_bottom_sheet.dart';
+import 'my_page_controller.dart';
 
 class RankingController extends GetxController {
   final RankingService rankingService = RankingService();
@@ -18,7 +19,7 @@ class RankingController extends GetxController {
 
   final RxBool isLoading = true.obs;
 
-  late final Rx<Ranking> myRanking;
+  late Rx<Ranking> myRanking;
   final RxInt selectedType = 0.obs;
   final RxList rankings = [].obs;
 
@@ -56,13 +57,29 @@ class RankingController extends GetxController {
   }
 
   updateRankingWithDelay(int seconds) async {
-    List<Ranking> rankings =
-        await rankingService.getAllUserRanking(selectedWeek);
-    Ranking myRanking = await rankingService.getUserRanking(
-      UserManager().getUserId()!,
-      selectedWeek,
-    );
     await Future.delayed(Duration(seconds: seconds));
+    await updateRanking();
+  }
+
+  Future<void> updateRanking() async {
+    List<Ranking> rankings;
+    Ranking myRanking;
+    if (selectedType.value == 0) {
+      rankings = await rankingService.getAllUserRanking(selectedWeek);
+      myRanking = await rankingService.getUserRanking(
+        UserManager().getUserId()!,
+        selectedWeek,
+      );
+    } else {
+      int? communityId =
+          Get.find<MyPageController>().currentUserInfo.value.communityId;
+      rankings = await rankingService.getAllCommunityRanking(selectedWeek);
+      myRanking = await rankingService.getCommunityRanking(
+        communityId,
+        selectedWeek,
+      );
+    }
+
     this.rankings.assignAll(rankings);
     this.myRanking.value = myRanking;
   }
@@ -121,11 +138,11 @@ class RankingController extends GetxController {
   void openRankingBottomSheet(Ranking ranking) async {
     FirebaseAnalytics.instance.logEvent(name: "ranking_element_click");
     UserPixelCount pixelCount =
-        await userService.getAnotherUserPixelCount(null, ranking.userId);
+        await userService.getAnotherUserPixelCount(null, ranking.id);
     Get.bottomSheet(
       RankingBottomSheet(
-        userId: ranking.userId,
-        nickname: ranking.nickname!,
+        userId: ranking.id,
+        nickname: ranking.name!,
         profileImageUrl: ranking.profileImageUrl,
         currentPixelCount: pixelCount.currentPixelCount!,
         accumulatePixelCount: pixelCount.accumulatePixelCount!,

--- a/lib/models/ranking.dart
+++ b/lib/models/ranking.dart
@@ -1,19 +1,19 @@
 class Ranking {
-  int userId;
-  String? nickname;
+  int id;
+  String? name;
   String? profileImageUrl;
   int? rank;
   int? currentPixelCount;
 
   Ranking({
-    required this.userId,
-    this.nickname,
+    required this.id,
+    this.name,
     this.profileImageUrl,
     required this.rank,
     required this.currentPixelCount,
   });
 
-  factory Ranking.fromJson(Map<String, dynamic> json) {
+  factory Ranking.fromJsonUser(Map<String, dynamic> json) {
     return switch (json) {
       {
         'userId': var userId,
@@ -23,8 +23,8 @@ class Ranking {
         'currentPixelCount': var currentPixelCount,
       } =>
         Ranking(
-          userId: userId,
-          nickname: nickname,
+          id: userId,
+          name: nickname,
           profileImageUrl: profileImageUrl,
           rank: rank,
           currentPixelCount: currentPixelCount,
@@ -33,9 +33,35 @@ class Ranking {
     };
   }
 
-  static List<Ranking> listFromJson(List<dynamic> jsonList) {
+  factory Ranking.fromJsonCommunity(Map<String, dynamic> json) {
+    return switch (json) {
+      {
+        'communityId': var communityId,
+        'name': var name,
+        'profileImageUrl': var profileImageUrl,
+        'rank': var rank,
+        'currentPixelCount': var currentPixelCount,
+      } =>
+        Ranking(
+          id: communityId,
+          name: name,
+          profileImageUrl: profileImageUrl,
+          rank: rank,
+          currentPixelCount: currentPixelCount,
+        ),
+      _ => throw const FormatException('Failed to load Ranking')
+    };
+  }
+
+  static List<Ranking> listFromJsonUser(List<dynamic> jsonList) {
     return [
-      for (var element in jsonList) Ranking.fromJson(element),
+      for (var element in jsonList) Ranking.fromJsonUser(element),
+    ];
+  }
+
+  static List<Ranking> listFromJsonCommunity(List<dynamic> jsonList) {
+    return [
+      for (var element in jsonList) Ranking.fromJsonCommunity(element),
     ];
   }
 }

--- a/lib/service/ranking_service.dart
+++ b/lib/service/ranking_service.dart
@@ -22,7 +22,7 @@ class RankingService {
       },
     );
 
-    return Ranking.listFromJson(response.data['data']);
+    return Ranking.listFromJsonUser(response.data['data']);
   }
 
   getUserRanking(int userId, DateTime lookupDate) async {
@@ -34,6 +34,33 @@ class RankingService {
       },
     );
 
-    return Ranking.fromJson(response.data['data']);
+    return Ranking.fromJsonUser(response.data['data']);
+  }
+
+  getAllCommunityRanking(DateTime lookupDate) async {
+    var response = await dio.get(
+      '/ranking/community',
+      queryParameters: {
+        'lookup-date':
+            '${lookupDate.year}-${lookupDate.month.toString().padLeft(2, '0')}-${lookupDate.day.toString().padLeft(2, '0')}',
+      },
+    );
+
+    return Ranking.listFromJsonCommunity(response.data['data']);
+  }
+
+  getCommunityRanking(int? communityId, DateTime lookupDate) async {
+    if (communityId == null) {
+      return Ranking.fromJsonCommunity({"communityId": 1});
+    }
+    var response = await dio.get(
+      '/ranking/community/${communityId.toString()}',
+      queryParameters: {
+        'lookup-date':
+            '${lookupDate.year}-${lookupDate.month.toString().padLeft(2, '0')}-${lookupDate.day.toString().padLeft(2, '0')}',
+      },
+    );
+
+    return Ranking.fromJsonCommunity(response.data['data']);
   }
 }

--- a/lib/widgets/common/app_bar.dart
+++ b/lib/widgets/common/app_bar.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
+import '../ranking/ranking_type_toggle_button.dart';
 
 class MapAppBar extends StatelessWidget {
   const MapAppBar({super.key});
@@ -24,18 +24,7 @@ class RankingAppBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return AppBar(
       backgroundColor: AppColors.background,
-      actions: [
-        IconButton(
-          icon: Icon(Icons.info_outline),
-          color: AppColors.buttonColor,
-          onPressed: () {
-            launchUrl(Uri.parse(rankingGuideUrl));
-          },
-        ),
-      ],
-      title: AppBarTitle(title: "주간 랭킹"),
-      // Todo: 그룹 기능 구현 시 활성화
-      // title: RankingTypeToggleButton(),
+      title: RankingTypeToggleButton(),
     );
   }
 }

--- a/lib/widgets/community/member/member_list.dart
+++ b/lib/widgets/community/member/member_list.dart
@@ -133,7 +133,7 @@ class RankingInfo extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                ranking.nickname ?? "알수없음",
+                ranking.name ?? "알수없음",
                 style: TextStyles.fs17w600cTextPrimary,
               ),
               if (ranking.currentPixelCount != null)

--- a/lib/widgets/ranking/ranking_info.dart
+++ b/lib/widgets/ranking/ranking_info.dart
@@ -39,7 +39,7 @@ class RankingInfo extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                ranking.nickname ?? "알수없음",
+                ranking.name ?? "알수없음",
                 style: TextStyles.fs17w600cTextPrimary,
               ),
               Spacer(),
@@ -127,7 +127,7 @@ class RankingInfoMy extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                ranking.nickname ?? "알수없음",
+                ranking.name ?? "알수없음",
                 style: TextStyles.fs17w600cTextPrimary,
               ),
               if (ranking.currentPixelCount != null)

--- a/lib/widgets/ranking/week_selector.dart
+++ b/lib/widgets/ranking/week_selector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
@@ -7,44 +8,57 @@ import '../../controllers/ranking_controller.dart';
 import 'week_wheel_picker.dart';
 
 class WeekSelector extends StatelessWidget {
+  static String rankingGuideUrl =
+      'https://autumn-blouse-355.notion.site/b90c1f81e247499ab244137634b066bc?pvs=4';
+
   const WeekSelector({super.key});
 
   @override
   Widget build(BuildContext context) {
     final RankingController rankingController = Get.find<RankingController>();
 
-    return SizedBox(
-      height: 44,
-      child: Padding(
-        padding: EdgeInsets.symmetric(vertical: 12, horizontal: 0),
-        child: GestureDetector(
-          onTap: () {
-            Get.bottomSheet(
-              WeekWheelPicker(),
-              backgroundColor: AppColors.backgroundSecondary,
-              enterBottomSheetDuration: Duration(milliseconds: 100),
-              exitBottomSheetDuration: Duration(milliseconds: 100),
-            );
-          },
-          child: Row(
-            children: [
-              Obx(() {
-                return Text(
-                  rankingController.selectedWeekString.value,
-                  style: TextStyles.fs17w700cTextPrimary,
-                );
-              }),
-              SizedBox(
-                width: 5,
-              ),
-              Image.asset(
-                "assets/images/chevron_down.png",
-                width: 20,
-                height: 20,
-              ),
-            ],
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: 0, horizontal: 0),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: () {
+              Get.bottomSheet(
+                WeekWheelPicker(),
+                backgroundColor: AppColors.backgroundSecondary,
+                enterBottomSheetDuration: Duration(milliseconds: 100),
+                exitBottomSheetDuration: Duration(milliseconds: 100),
+              );
+            },
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Obx(() {
+                  return Text(
+                    rankingController.selectedWeekString.value,
+                    style: TextStyles.fs17w700cTextPrimary,
+                  );
+                }),
+                SizedBox(
+                  width: 5,
+                ),
+                Image.asset(
+                  "assets/images/chevron_down.png",
+                  width: 20,
+                  height: 20,
+                ),
+              ],
+            ),
           ),
-        ),
+          Spacer(),
+          IconButton(
+            icon: Icon(Icons.info_outline),
+            color: AppColors.buttonColor,
+            onPressed: () {
+              launchUrl(Uri.parse(rankingGuideUrl));
+            },
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## 작업 내용*
- 그룹전 랭킹 기능 구현

## 고민한 내용*
### Ranking 모델
```
class Ranking {
  int userId;
  String? nickname;
  String? profileImageUrl;
  int? rank;
  int? currentPixelCount;
}
```
처음에 코드를 구현할 때 Ranking 클래스를 user 랭킹에 너무 종속되게 구현을 해두었다. 필드에 user 와 nickname 이 있어 그룹에 재활용하기에는 이름이 문제가 되었다.
그렇다고 RankingCommunity 로 새로 클래스를 만들자니 랭킹 페이지의 모든 위젯이 위 Ranking 클래스를 참조하고 있어 모든 부분을 새로 만들어야하는 번거로움이 있었다.
#### 해결책
- 해결책으로 그냥 그룹 api 도 userId 에 communityId 를 넣는 방식으로 억지 스럽게 해결하려 했으나 나중에 더 헷갈릴 것 같아 기각했다.
- 랭킹위젯을 전부다 새로 만드는 것은 번거로워서 기각 했다.
- 결국 위 Ranking 클래스의 필드를 id와 name 으로 바꾸고 생성자를 user 와 community 로 분리했다.


아직 API 가 완성되지 않아 앱을 켰을 때 그룹 페이지가 나타나지 않는다.

## 리뷰 요구사항
- 리뷰할 때 중점적으로 봐줬으면 하는 내용들
## 스크린샷
![Simulator Screenshot - iPhone 15 Pro - 2024-09-09 at 15 37 44](https://github.com/user-attachments/assets/4b4f7168-030f-4865-9da9-71332a8e2049)
