### PR TITLE
M3-338 그룹 멤버 상세보기 페이지 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Flutter CI
 on:
   pull_request:
     branches:
-      - develop
+      - develop*
 
 jobs:
   test:

--- a/lib/controllers/community_controller.dart
+++ b/lib/controllers/community_controller.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 
+import '../enums/ranking_kind.dart';
 import '../models/community.dart';
 import '../models/ranking.dart';
 import '../service/community_service.dart';
@@ -21,11 +22,41 @@ class CommunityController extends GetxController {
   final RxBool isLoading = true.obs;
 
   final RxList members = [
-    Ranking(id: 1, rank: 1, currentPixelCount: 123, name: "test1"),
-    Ranking(id: 1, rank: 2, currentPixelCount: 123, name: "test2"),
-    Ranking(id: 1, rank: 3, currentPixelCount: 123, name: "test3"),
-    Ranking(id: 1, rank: 4, currentPixelCount: 123, name: "test4"),
-    Ranking(id: 1, rank: 5, currentPixelCount: 123, name: "test5"),
+    Ranking(
+      id: 1,
+      rank: 1,
+      currentPixelCount: 123,
+      name: "test1",
+      kind: RankingKind.community,
+    ),
+    Ranking(
+      id: 1,
+      rank: 2,
+      currentPixelCount: 123,
+      name: "test2",
+      kind: RankingKind.community,
+    ),
+    Ranking(
+      id: 1,
+      rank: 3,
+      currentPixelCount: 123,
+      name: "test3",
+      kind: RankingKind.community,
+    ),
+    Ranking(
+      id: 1,
+      rank: 4,
+      currentPixelCount: 123,
+      name: "test4",
+      kind: RankingKind.community,
+    ),
+    Ranking(
+      id: 1,
+      rank: 5,
+      currentPixelCount: 123,
+      name: "test5",
+      kind: RankingKind.community,
+    ),
   ].obs;
 
   init() async {

--- a/lib/controllers/community_info_controller.dart
+++ b/lib/controllers/community_info_controller.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 
+import '../enums/ranking_kind.dart';
 import '../models/community.dart';
 import '../models/ranking.dart';
 import '../service/community_service.dart';
@@ -20,11 +21,41 @@ class CommunityInfoController extends GetxController {
   final RxBool isLoading = true.obs;
 
   final RxList members = [
-    Ranking(id: 1, rank: 1, currentPixelCount: 123, name: "test1"),
-    Ranking(id: 1, rank: 2, currentPixelCount: 123, name: "test2"),
-    Ranking(id: 1, rank: 3, currentPixelCount: 123, name: "test3"),
-    Ranking(id: 1, rank: 4, currentPixelCount: 123, name: "test4"),
-    Ranking(id: 1, rank: 5, currentPixelCount: 123, name: "test5"),
+    Ranking(
+      id: 1,
+      rank: 1,
+      currentPixelCount: 123,
+      name: "test1",
+      kind: RankingKind.community,
+    ),
+    Ranking(
+      id: 1,
+      rank: 2,
+      currentPixelCount: 123,
+      name: "test2",
+      kind: RankingKind.community,
+    ),
+    Ranking(
+      id: 1,
+      rank: 3,
+      currentPixelCount: 123,
+      name: "test3",
+      kind: RankingKind.community,
+    ),
+    Ranking(
+      id: 1,
+      rank: 4,
+      currentPixelCount: 123,
+      name: "test4",
+      kind: RankingKind.community,
+    ),
+    Ranking(
+      id: 1,
+      rank: 5,
+      currentPixelCount: 123,
+      name: "test5",
+      kind: RankingKind.community,
+    ),
   ].obs;
 
   init(int communityId) async {

--- a/lib/controllers/community_member_controller.dart
+++ b/lib/controllers/community_member_controller.dart
@@ -10,7 +10,7 @@ class CommunityMemberController extends GetxController {
 
   init(int communityId) async {
     this.communityId = communityId;
-    loadMembers();
+    await loadMembers();
     isLoading.value = false;
   }
 

--- a/lib/controllers/community_member_controller.dart
+++ b/lib/controllers/community_member_controller.dart
@@ -6,13 +6,16 @@ class CommunityMemberController extends GetxController {
   final CommunityService communityService = CommunityService();
   final RxList members = [].obs;
   final RxBool isLoading = true.obs;
+  late int communityId;
 
   init(int communityId) async {
-    print(1);
-    var members = await communityService.getMembers(communityId);
-    this.members.assignAll(members);
+    this.communityId = communityId;
+    loadMembers();
     isLoading.value = false;
   }
 
-  reloadMembers() {}
+  loadMembers() async {
+    var members = await communityService.getMembers(communityId);
+    this.members.assignAll(members);
+  }
 }

--- a/lib/controllers/community_member_controller.dart
+++ b/lib/controllers/community_member_controller.dart
@@ -1,0 +1,18 @@
+import 'package:get/get.dart';
+
+import '../service/community_service.dart';
+
+class CommunityMemberController extends GetxController {
+  final CommunityService communityService = CommunityService();
+  final RxList members = [].obs;
+  final RxBool isLoading = true.obs;
+
+  init(int communityId) async {
+    print(1);
+    var members = await communityService.getMembers(communityId);
+    this.members.assignAll(members);
+    isLoading.value = false;
+  }
+
+  reloadMembers() {}
+}

--- a/lib/controllers/ranking_controller.dart
+++ b/lib/controllers/ranking_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../constants/app_colors.dart';
+import '../enums/ranking_kind.dart';
 import '../models/ranking.dart';
 import '../models/user_pixel_count.dart';
 import '../service/ranking_service.dart';
@@ -137,19 +138,21 @@ class RankingController extends GetxController {
 
   void openRankingBottomSheet(Ranking ranking) async {
     FirebaseAnalytics.instance.logEvent(name: "ranking_element_click");
-    UserPixelCount pixelCount =
-        await userService.getAnotherUserPixelCount(null, ranking.id);
-    Get.bottomSheet(
-      RankingBottomSheet(
-        userId: ranking.id,
-        nickname: ranking.name!,
-        profileImageUrl: ranking.profileImageUrl,
-        currentPixelCount: pixelCount.currentPixelCount!,
-        accumulatePixelCount: pixelCount.accumulatePixelCount!,
-      ),
-      backgroundColor: AppColors.background,
-      enterBottomSheetDuration: Duration(milliseconds: 100),
-      exitBottomSheetDuration: Duration(milliseconds: 100),
-    );
+    if (ranking.kind == RankingKind.user) {
+      UserPixelCount pixelCount =
+          await userService.getAnotherUserPixelCount(null, ranking.id);
+      Get.bottomSheet(
+        RankingBottomSheet(
+          userId: ranking.id,
+          nickname: ranking.name!,
+          profileImageUrl: ranking.profileImageUrl,
+          currentPixelCount: pixelCount.currentPixelCount!,
+          accumulatePixelCount: pixelCount.accumulatePixelCount!,
+        ),
+        backgroundColor: AppColors.background,
+        enterBottomSheetDuration: Duration(milliseconds: 100),
+        exitBottomSheetDuration: Duration(milliseconds: 100),
+      );
+    }
   }
 }

--- a/lib/enums/ranking_kind.dart
+++ b/lib/enums/ranking_kind.dart
@@ -1,0 +1,4 @@
+enum RankingKind {
+  user,
+  community,
+}

--- a/lib/models/ranking.dart
+++ b/lib/models/ranking.dart
@@ -1,9 +1,12 @@
+import '../enums/ranking_kind.dart';
+
 class Ranking {
   int id;
   String? name;
   String? profileImageUrl;
   int? rank;
   int? currentPixelCount;
+  RankingKind kind;
 
   Ranking({
     required this.id,
@@ -11,6 +14,7 @@ class Ranking {
     this.profileImageUrl,
     required this.rank,
     required this.currentPixelCount,
+    required this.kind,
   });
 
   factory Ranking.fromJsonUser(Map<String, dynamic> json) {
@@ -28,6 +32,7 @@ class Ranking {
           profileImageUrl: profileImageUrl,
           rank: rank,
           currentPixelCount: currentPixelCount,
+          kind: RankingKind.user,
         ),
       _ => throw const FormatException('Failed to load Ranking')
     };
@@ -48,6 +53,7 @@ class Ranking {
           profileImageUrl: profileImageUrl,
           rank: rank,
           currentPixelCount: currentPixelCount,
+          kind: RankingKind.community,
         ),
       _ => throw const FormatException('Failed to load Ranking')
     };

--- a/lib/screens/community_info_screen.dart
+++ b/lib/screens/community_info_screen.dart
@@ -11,18 +11,18 @@ import '../widgets/community/community_record.dart';
 import '../widgets/community/member/member_list.dart';
 
 class CommunityInfoScreen extends StatelessWidget {
-  final int groupId;
+  final int communityId;
 
   const CommunityInfoScreen({
     super.key,
-    required this.groupId,
+    required this.communityId,
   });
 
   @override
   Widget build(BuildContext context) {
     final CommunityInfoController communityInfoController =
         Get.put(CommunityInfoController());
-    communityInfoController.init(groupId);
+    communityInfoController.init(communityId);
 
     return Scaffold(
       backgroundColor: Colors.black,
@@ -119,7 +119,11 @@ class CommunityInfoScreen extends StatelessWidget {
                       SizedBox(
                         height: 20,
                       ),
-                      MemberList(members: communityInfoController.members),
+                      MemberList(
+                        members: communityInfoController.members,
+                        communityName: communityInfoController.name.value,
+                        communityId: communityId,
+                      ),
                       SizedBox(
                         height: 20,
                       ),

--- a/lib/screens/community_member_screen.dart
+++ b/lib/screens/community_member_screen.dart
@@ -22,6 +22,7 @@ class CommunityMemberScreen extends StatelessWidget {
         Get.put(CommunityMemberController());
     communityMemberController.init(communityId);
     List members = communityMemberController.members;
+
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(

--- a/lib/screens/community_member_screen.dart
+++ b/lib/screens/community_member_screen.dart
@@ -10,8 +10,11 @@ class CommunityMemberScreen extends StatelessWidget {
   final String communityName;
   final int communityId;
 
-  CommunityMemberScreen(
-      {super.key, required this.communityName, required this.communityId});
+  CommunityMemberScreen({
+    super.key,
+    required this.communityName,
+    required this.communityId,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -20,44 +23,47 @@ class CommunityMemberScreen extends StatelessWidget {
     communityMemberController.init(communityId);
     List members = communityMemberController.members;
     return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
         backgroundColor: AppColors.background,
-        appBar: AppBar(
-          backgroundColor: AppColors.background,
-          title: Text(
-            communityName,
-            style: TextStyles.fs20w700cTextPrimary,
-          ),
-          leading: IconButton(
-            icon: Icon(Icons.arrow_back_ios),
-            color: AppColors.buttonColor,
-            onPressed: () {
-              Get.back();
-            },
-          ),
+        title: Text(
+          communityName,
+          style: TextStyles.fs20w700cTextPrimary,
         ),
-        body: Obx(() {
-          if (communityMemberController.isLoading.value) {
-            return const Center(
-              child: CircularProgressIndicator(
-                color: AppColors.primary,
-              ),
-            );
-          } else {
-            return RefreshIndicator(
-              onRefresh: () async {
-                await communityMemberController.reloadMembers();
-              },
-              child: ListView(
-                children: [
-                  for (int i = 0; i < members.length; i++)
-                    MemberListElement(
-                      ranking: members[i],
-                      isLast: i == members.length - 1 ? true : false,
-                    ),
-                ],
-              ),
-            );
-          }
-        }));
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back_ios),
+          color: AppColors.buttonColor,
+          onPressed: () {
+            Get.back();
+          },
+        ),
+      ),
+      body: Obx(() {
+        if (communityMemberController.isLoading.value) {
+          return const Center(
+            child: CircularProgressIndicator(
+              color: AppColors.primary,
+            ),
+          );
+        } else {
+          return RefreshIndicator(
+            color: AppColors.primary,
+            backgroundColor: AppColors.backgroundThird,
+            onRefresh: () async {
+              await communityMemberController.loadMembers();
+            },
+            child: ListView(
+              children: [
+                for (int i = 0; i < members.length; i++)
+                  MemberListElement(
+                    ranking: members[i],
+                    isLast: i == members.length - 1 ? true : false,
+                  ),
+              ],
+            ),
+          );
+        }
+      }),
+    );
   }
 }

--- a/lib/screens/community_member_screen.dart
+++ b/lib/screens/community_member_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../constants/app_colors.dart';
+import '../constants/text_styles.dart';
+
+class CommunityMemberScreen extends StatelessWidget {
+  final String communityName;
+
+  const CommunityMemberScreen({super.key, required this.communityName});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        title: Text(
+          communityName,
+          style: TextStyles.fs20w700cTextPrimary,
+        ),
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back_ios),
+          color: AppColors.buttonColor,
+          onPressed: () {
+            Get.back();
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/community_member_screen.dart
+++ b/lib/screens/community_member_screen.dart
@@ -3,30 +3,61 @@ import 'package:get/get.dart';
 
 import '../constants/app_colors.dart';
 import '../constants/text_styles.dart';
+import '../controllers/community_member_controller.dart';
+import '../widgets/community/member/member_list.dart';
 
 class CommunityMemberScreen extends StatelessWidget {
   final String communityName;
+  final int communityId;
 
-  const CommunityMemberScreen({super.key, required this.communityName});
+  CommunityMemberScreen(
+      {super.key, required this.communityName, required this.communityId});
 
   @override
   Widget build(BuildContext context) {
+    final CommunityMemberController communityMemberController =
+        Get.put(CommunityMemberController());
+    communityMemberController.init(communityId);
+    List members = communityMemberController.members;
     return Scaffold(
-      backgroundColor: AppColors.background,
-      appBar: AppBar(
         backgroundColor: AppColors.background,
-        title: Text(
-          communityName,
-          style: TextStyles.fs20w700cTextPrimary,
+        appBar: AppBar(
+          backgroundColor: AppColors.background,
+          title: Text(
+            communityName,
+            style: TextStyles.fs20w700cTextPrimary,
+          ),
+          leading: IconButton(
+            icon: Icon(Icons.arrow_back_ios),
+            color: AppColors.buttonColor,
+            onPressed: () {
+              Get.back();
+            },
+          ),
         ),
-        leading: IconButton(
-          icon: Icon(Icons.arrow_back_ios),
-          color: AppColors.buttonColor,
-          onPressed: () {
-            Get.back();
-          },
-        ),
-      ),
-    );
+        body: Obx(() {
+          if (communityMemberController.isLoading.value) {
+            return const Center(
+              child: CircularProgressIndicator(
+                color: AppColors.primary,
+              ),
+            );
+          } else {
+            return RefreshIndicator(
+              onRefresh: () async {
+                await communityMemberController.reloadMembers();
+              },
+              child: ListView(
+                children: [
+                  for (int i = 0; i < members.length; i++)
+                    MemberListElement(
+                      ranking: members[i],
+                      isLast: i == members.length - 1 ? true : false,
+                    ),
+                ],
+              ),
+            );
+          }
+        }));
   }
 }

--- a/lib/screens/community_screen.dart
+++ b/lib/screens/community_screen.dart
@@ -112,7 +112,11 @@ class CommunityScreen extends StatelessWidget {
                       SizedBox(
                         height: 20,
                       ),
-                      MemberList(members: communityController.members),
+                      MemberList(
+                        members: communityController.members,
+                        communityName: communityController.name.value,
+                        communityId: communityController.communityId.value,
+                      ),
                       SizedBox(
                         height: 20,
                       ),

--- a/lib/service/community_service.dart
+++ b/lib/service/community_service.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 
 import '../models/community.dart';
+import '../models/ranking.dart';
 import '../models/search_community_response.dart';
 import '../utils/dio_service.dart';
 
@@ -29,7 +30,7 @@ class CommunityService {
     return SearchCommunityResponse.listFromJson(response.data['data']);
   }
 
-  Future<List> getMembers(int communityId) async {
+  Future<List<Ranking>> getMembers(int communityId) async {
     return [];
   }
 }

--- a/lib/service/community_service.dart
+++ b/lib/service/community_service.dart
@@ -28,4 +28,8 @@ class CommunityService {
     );
     return SearchCommunityResponse.listFromJson(response.data['data']);
   }
+
+  Future<List> getMembers(int communityId) async {
+    return [];
+  }
 }

--- a/lib/service/community_service.dart
+++ b/lib/service/community_service.dart
@@ -31,6 +31,10 @@ class CommunityService {
   }
 
   Future<List<Ranking>> getMembers(int communityId) async {
-    return [];
+    var response = await dio.get(
+      '/community/{communityId}/members',
+    );
+
+    return Ranking.listFromJsonUser(response.data['data']);
   }
 }

--- a/lib/widgets/community/community_list.dart
+++ b/lib/widgets/community/community_list.dart
@@ -8,12 +8,13 @@ import '../../constants/app_colors.dart';
 import '../../screens/community_info_screen.dart';
 
 class CommunityList extends StatelessWidget {
-  const CommunityList(
-      {super.key,
-      required this.imageUrl,
-      required this.communityName,
-      required this.isSearched,
-      required this.communityId,});
+  const CommunityList({
+    super.key,
+    required this.imageUrl,
+    required this.communityName,
+    required this.isSearched,
+    required this.communityId,
+  });
 
   final String imageUrl;
   final String communityName;
@@ -26,7 +27,7 @@ class CommunityList extends StatelessWidget {
       title: InkWell(
         onTap: () {
           Get.to(
-            () => CommunityInfoScreen(groupId: communityId),
+            () => CommunityInfoScreen(communityId: communityId),
           );
         },
         child: Row(

--- a/lib/widgets/community/member/member_list.dart
+++ b/lib/widgets/community/member/member_list.dart
@@ -7,6 +7,7 @@ import '../../../constants/app_colors.dart';
 import '../../../constants/text_styles.dart';
 import '../../../controllers/ranking_controller.dart';
 import '../../../models/ranking.dart';
+import '../../../screens/community_member_screen.dart';
 import '../../ranking/ranking_info.dart';
 
 class MemberList extends StatelessWidget {
@@ -32,19 +33,24 @@ class MemberList extends StatelessWidget {
                   "멤버",
                   style: TextStyles.fs24w900cTextPrimary,
                 ),
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Text(
-                      "더보기",
-                      style: TextStyles.fs14w600cTextSecondary,
-                    ),
-                    Icon(
-                      Icons.arrow_forward_ios,
-                      color: AppColors.textSecondary,
-                      size: 10,
-                    ),
-                  ],
+                GestureDetector(
+                  onTap: () {
+                    Get.to(CommunityMemberScreen(communityName: '세종대'));
+                  },
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Text(
+                        "더보기",
+                        style: TextStyles.fs14w600cTextSecondary,
+                      ),
+                      Icon(
+                        Icons.arrow_forward_ios,
+                        color: AppColors.textSecondary,
+                        size: 10,
+                      ),
+                    ],
+                  ),
                 ),
               ],
             ),

--- a/lib/widgets/community/member/member_list.dart
+++ b/lib/widgets/community/member/member_list.dart
@@ -11,9 +11,16 @@ import '../../../screens/community_member_screen.dart';
 import '../../ranking/ranking_info.dart';
 
 class MemberList extends StatelessWidget {
+  final String communityName;
+  final int communityId;
   final List members;
 
-  const MemberList({super.key, required this.members});
+  const MemberList({
+    super.key,
+    required this.members,
+    required this.communityName,
+    required this.communityId,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -35,7 +42,10 @@ class MemberList extends StatelessWidget {
                 ),
                 GestureDetector(
                   onTap: () {
-                    Get.to(CommunityMemberScreen(communityName: '세종대'));
+                    Get.to(CommunityMemberScreen(
+                      communityName: communityName,
+                      communityId: communityId,
+                    ));
                   },
                   child: Row(
                     crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/widgets/community/member/member_list.dart
+++ b/lib/widgets/community/member/member_list.dart
@@ -42,10 +42,12 @@ class MemberList extends StatelessWidget {
                 ),
                 GestureDetector(
                   onTap: () {
-                    Get.to(CommunityMemberScreen(
-                      communityName: communityName,
-                      communityId: communityId,
-                    ));
+                    Get.to(
+                      CommunityMemberScreen(
+                        communityName: communityName,
+                        communityId: communityId,
+                      ),
+                    );
                   },
                   child: Row(
                     crossAxisAlignment: CrossAxisAlignment.center,


### PR DESCRIPTION
## 작업 내용*
- 그룹 멤버 상세보기 페이지 구현

## 고민한 내용*
- 당겨서 새로 고침을 구현했다.
- 멤버를 터치하면 기존의 랭킹 처럼 유저의 상세 정보가 그대로 뜨게 구현해두었다.

## 리뷰 요구사항
### 그룹 멤버 조회 api 
`GET /api/communities/{communityId}/members`
- Response
```
  {
    'userId': userId,
    'nickname': nickname,
    'profileImageUrl': profileImageUrl,
    'rank': rank,
    'currentPixelCount': currentPixelCount,
  }
```
## 스크린샷
![Simulator Screenshot - iPhone 15 Pro - 2024-09-10 at 01 58 09](https://github.com/user-attachments/assets/5f85de48-e290-4657-9025-3d7d4bdd27ca)
