### PR TITLE
프론트 걸음수 제거

### DIFF
--- a/lib/controllers/bottom_sheet_controller.dart
+++ b/lib/controllers/bottom_sheet_controller.dart
@@ -6,6 +6,9 @@ import '../models/community_mode_pixel_info.dart';
 import '../models/individual_history_pixel_info.dart';
 import '../models/individual_mode_pixel_info.dart';
 import '../service/pixel_service.dart';
+import '../widgets/map/bottom_sheet/bottom_stats.dart';
+import '../widgets/map/bottom_sheet/bottom_stats.dart';
+import '../widgets/map/bottom_sheet/bottom_stats.dart';
 import '../widgets/map/bottom_sheet/individual_history_list.dart';
 import '../widgets/map/bottom_sheet/pixel_info_header.dart';
 import '../widgets/map/bottom_sheet/step_stats.dart';
@@ -17,8 +20,8 @@ class BottomSheetController extends GetxController {
   final DraggableScrollableController draggableController =
       DraggableScrollableController();
 
-  Widget currentBody = StepStatsBody();
-  Widget currentHeader = StepStats();
+  Widget currentBody = BottomStatsBody();
+  Widget currentHeader = BottomStats();
   RxInt mode = 0.obs;
   RxBool changeVar = true.obs;
   double size = 1.1;
@@ -95,8 +98,8 @@ class BottomSheetController extends GetxController {
   }
 
   minimize() {
-    currentHeader = StepStats();
-    currentBody = StepStatsBody();
+    currentHeader = BottomStats();
+    currentBody = BottomStatsBody();
     mode.value = 0;
     draggableController.animateTo(
       0.1,
@@ -107,8 +110,8 @@ class BottomSheetController extends GetxController {
 
   void changeStepStatIfMinimized() {
     if (draggableController.size <= 0.111 && size > draggableController.size) {
-      currentHeader = StepStats();
-      currentBody = StepStatsBody();
+      currentHeader = BottomStats();
+      currentBody = BottomStatsBody();
       mode.value = 0;
 
       Get.find<MapController>().changePixelToNormalState();

--- a/lib/controllers/bottom_sheet_controller.dart
+++ b/lib/controllers/bottom_sheet_controller.dart
@@ -7,11 +7,8 @@ import '../models/individual_history_pixel_info.dart';
 import '../models/individual_mode_pixel_info.dart';
 import '../service/pixel_service.dart';
 import '../widgets/map/bottom_sheet/bottom_stats.dart';
-import '../widgets/map/bottom_sheet/bottom_stats.dart';
-import '../widgets/map/bottom_sheet/bottom_stats.dart';
 import '../widgets/map/bottom_sheet/individual_history_list.dart';
 import '../widgets/map/bottom_sheet/pixel_info_header.dart';
-import '../widgets/map/bottom_sheet/step_stats.dart';
 import '../widgets/map/bottom_sheet/visited_user_list.dart';
 import 'map_controller.dart';
 

--- a/lib/controllers/walking_controller.dart
+++ b/lib/controllers/walking_controller.dart
@@ -31,6 +31,7 @@ class WalkingController extends GetxController {
     // _initializeUpdateTimer();
   }
 
+  // ignore: unused_element
   void _initializeUpdateTimer() {
     int updateInterval = Platform.isIOS ? 15 : 1;
     Timer.periodic(Duration(seconds: updateInterval), (timer) {
@@ -38,6 +39,7 @@ class WalkingController extends GetxController {
     });
   }
 
+  // ignore: unused_element
   void _initializeCurrentStep() async {
     int stepCount = await walkingService.getCurrentStep();
     if (stepCount != 0) {
@@ -45,6 +47,7 @@ class WalkingController extends GetxController {
     }
   }
 
+  // ignore: unused_element
   Future<void> _initializeWeeklySteps() async {
     DateTime nowDate = DateTime.now();
     selectedWeekStartDate =

--- a/lib/controllers/walking_controller.dart
+++ b/lib/controllers/walking_controller.dart
@@ -26,9 +26,9 @@ class WalkingController extends GetxController {
   void onInit() {
     super.onInit();
     walkingService = WalkingServiceFactory.getWalkingService();
-    _initializeWeeklySteps();
-    _initializeCurrentStep();
-    _initializeUpdateTimer();
+    // _initializeWeeklySteps();
+    // _initializeCurrentStep();
+    // _initializeUpdateTimer();
   }
 
   void _initializeUpdateTimer() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,7 +49,7 @@ Future<void> main() async {
 
   FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
   FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
-    String? title = message.notification!.title;
+    // String? title = message.notification!.title;
 
     // await AlarmService.initializeStepCount(title);
   });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,7 +51,7 @@ Future<void> main() async {
   FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
     String? title = message.notification!.title;
 
-    await AlarmService.initializeStepCount(title);
+    // await AlarmService.initializeStepCount(title);
   });
 
   KakaoSdk.init(nativeAppKey: dotenv.env['NATIVE_APP_KEY']!);

--- a/lib/screens/my_page_screen.dart
+++ b/lib/screens/my_page_screen.dart
@@ -5,8 +5,6 @@ import '../controllers/my_page_controller.dart';
 import '../controllers/walking_controller.dart';
 import '../widgets/my_page/pixel_bar_chart.dart';
 import '../widgets/my_page/pixel_dash_board.dart';
-import '../widgets/my_page/step_bar_chart.dart';
-import '../widgets/my_page/today_step_chart.dart';
 import '../widgets/my_page/user_info.dart';
 
 class MyPageScreen extends StatelessWidget {

--- a/lib/screens/my_page_screen.dart
+++ b/lib/screens/my_page_screen.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 
 import '../controllers/my_page_controller.dart';
 import '../controllers/walking_controller.dart';
+import '../widgets/my_page/pixel_bar_chart.dart';
 import '../widgets/my_page/pixel_dash_board.dart';
 import '../widgets/my_page/step_bar_chart.dart';
 import '../widgets/my_page/today_step_chart.dart';
@@ -28,11 +29,11 @@ class MyPageScreen extends StatelessWidget {
           SizedBox(
             height: 20,
           ),
-          TodayStepChart(),
+          // TodayStepChart(),
           SizedBox(
             height: 20,
           ),
-          StepBarChart(),
+          PixelBarChart(),
         ],
       ),
     );

--- a/lib/service/alarm_service.dart
+++ b/lib/service/alarm_service.dart
@@ -25,10 +25,7 @@ class AlarmService {
           await secureStorage.secureStorage.write(key: currentStepKey, value: '0');
           AndroidWalkingHandler.currentSteps = 0;
 
-          FlutterForegroundTask.updateService(
-            notificationTitle: "걸음수",
-            notificationText: 0.toString(),
-          );
+          FlutterForegroundTask.restartService();
         }
       }
     }

--- a/lib/service/android_walking_service.dart
+++ b/lib/service/android_walking_service.dart
@@ -26,7 +26,7 @@ class AndroidWalkingService implements WalkingService {
   late Stream<PedestrianStatus> _pedestrianStatusStream;
 
   AndroidWalkingService._internal() {
-    _initForegroundWalkingTask();
+    // _initForegroundWalkingTask();
   }
 
   factory AndroidWalkingService() {

--- a/lib/service/android_walking_service.dart
+++ b/lib/service/android_walking_service.dart
@@ -93,6 +93,7 @@ class AndroidWalkingService implements WalkingService {
     });
   }
 
+  // ignore: unused_element
   Future<void> _initForegroundWalkingTask() async {
     if (Platform.isAndroid) {
       initForegroundTask();

--- a/lib/widgets/map/bottom_sheet/bottom_stats.dart
+++ b/lib/widgets/map/bottom_sheet/bottom_stats.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:intl/intl.dart';
 
 import '../../../constants/app_colors.dart';
-import '../../../constants/text_styles.dart';
 import '../../../controllers/map_controller.dart';
-import '../../../controllers/walking_controller.dart';
 import '../../../screens/explore_mode_screen.dart';
 
 class BottomStats extends StatelessWidget {

--- a/lib/widgets/map/bottom_sheet/bottom_stats.dart
+++ b/lib/widgets/map/bottom_sheet/bottom_stats.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+
+import '../../../constants/app_colors.dart';
+import '../../../constants/text_styles.dart';
+import '../../../controllers/map_controller.dart';
+import '../../../controllers/walking_controller.dart';
+import '../../../screens/explore_mode_screen.dart';
+
+class BottomStats extends StatelessWidget {
+  const BottomStats({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [],
+    );
+  }
+}
+
+// Todo: 추후에 대시보드 등의 형식으로 변경 필요
+class BottomStatsBody extends StatelessWidget {
+  const BottomStatsBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Column(
+        children: [
+          SizedBox(
+            height: 200,
+          ),
+          TextButton(
+            onPressed: () {
+              Get.find<MapController>().startExplore();
+              Get.to(ExploreModeScreen());
+            },
+            style: TextButton.styleFrom(
+              backgroundColor: AppColors.backgroundThird,
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20.0),
+              child: Text(
+                '점령 모드',
+                style: TextStyle(
+                  fontSize: 20,
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/my_page/pixel_bar_chart.dart
+++ b/lib/widgets/my_page/pixel_bar_chart.dart
@@ -1,11 +1,6 @@
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-import 'package:intl/intl.dart';
 
 import '../../constants/app_colors.dart';
-import '../../constants/text_styles.dart';
-import '../../controllers/walking_controller.dart';
 
 class PixelBarChart extends StatelessWidget {
   PixelBarChart({super.key});

--- a/lib/widgets/my_page/pixel_bar_chart.dart
+++ b/lib/widgets/my_page/pixel_bar_chart.dart
@@ -1,0 +1,214 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+
+import '../../constants/app_colors.dart';
+import '../../constants/text_styles.dart';
+import '../../controllers/walking_controller.dart';
+
+class PixelBarChart extends StatelessWidget {
+  PixelBarChart({super.key});
+
+  // final WalkingController walkController = Get.find<WalkingController>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppColors.backgroundSecondary,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        // child: Column(
+        //   children: [
+        //     Padding(
+        //       padding: const EdgeInsets.fromLTRB(0.0, 0, 20, 0),
+        //       child: Row(
+        //         mainAxisAlignment: MainAxisAlignment.start,
+        //         children: [
+        //           Obx(
+        //             () => GestureDetector(
+        //               onTap: walkController.getIsPreviousButtonEnabled()
+        //                   ? () {
+        //                       walkController.loadPreviousWeekSteps();
+        //                     }
+        //                   : null,
+        //               child: Container(
+        //                 decoration: BoxDecoration(
+        //                   color: AppColors.backgroundSecondary,
+        //                   borderRadius: BorderRadius.all(Radius.circular(16)),
+        //                 ),
+        //                 padding: const EdgeInsets.fromLTRB(20.0, 20, 10, 20),
+        //                 child: Icon(
+        //                   Icons.arrow_back_ios_new_outlined,
+        //                   color: AppColors.textPrimary,
+        //                   size: 20,
+        //                 ),
+        //               ),
+        //             ),
+        //           ),
+        //           GestureDetector(
+        //             child: Obx(
+        //               () => Text(
+        //                 walkController.getSelectedWeekInfo(),
+        //                 style: TextStyles.fs17w600cTextPrimary,
+        //               ),
+        //             ),
+        //           ),
+        //           Obx(
+        //             () => GestureDetector(
+        //               onTap: walkController.getIsNextButtonEnabled()
+        //                   ? () {
+        //                       walkController.loadNextWeekSteps();
+        //                     }
+        //                   : null,
+        //               child: Container(
+        //                 decoration: BoxDecoration(
+        //                   color: AppColors.backgroundSecondary,
+        //                   borderRadius: BorderRadius.all(Radius.circular(16)),
+        //                 ),
+        //                 padding: const EdgeInsets.fromLTRB(10.0, 20, 20, 20),
+        //                 child: Icon(
+        //                   Icons.arrow_forward_ios_outlined,
+        //                   color: AppColors.textPrimary,
+        //                   size: 20,
+        //                 ),
+        //               ),
+        //             ),
+        //           ),
+        //         ],
+        //       ),
+        //     ),
+        //     Expanded(
+        //       child: Obx(
+        //         () => Padding(
+        //           padding: const EdgeInsets.all(20.0),
+        //           child: BarChart(
+        //             BarChartData(
+        //               barTouchData: getBarTouchData(),
+        //               titlesData: getTitlesData(walkController.getMaxStep()),
+        //               borderData: borderData,
+        //               barGroups: getBarGroups(walkController.getWeeklySteps()),
+        //               gridData: FlGridData(
+        //                 show: true,
+        //                 drawVerticalLine: false,
+        //                 horizontalInterval: walkController.getMaxStep() / 4,
+        //               ),
+        //               alignment: BarChartAlignment.spaceAround,
+        //               maxY: walkController.getMaxStep(),
+        //             ),
+        //           ),
+        //         ),
+        //       ),
+        //     ),
+        //   ],
+        // ),
+      ),
+    );
+  }
+  //
+  // BarTouchData get barTouchData => BarTouchData(
+  //       enabled: false,
+  //     );
+  //
+  // Widget getTitles(double value, TitleMeta meta) {
+  //   final bottomTitles = ['월', '화', '수', '목', '금', '토', '일'];
+  //   final style = TextStyles.fs14w400cTextSecondary;
+  //   String text = bottomTitles[value.toInt()];
+  //   return SideTitleWidget(
+  //     axisSide: meta.axisSide,
+  //     child: Text(text, style: style),
+  //   );
+  // }
+  //
+  // FlTitlesData getTitlesData(maxStep) => FlTitlesData(
+  //       show: true,
+  //       bottomTitles: AxisTitles(
+  //         sideTitles: SideTitles(
+  //           showTitles: true,
+  //           reservedSize: 30,
+  //           getTitlesWidget: getTitles,
+  //         ),
+  //       ),
+  //       leftTitles: const AxisTitles(
+  //         sideTitles: SideTitles(showTitles: false),
+  //       ),
+  //       topTitles: const AxisTitles(
+  //         sideTitles: SideTitles(showTitles: false),
+  //       ),
+  //       rightTitles: AxisTitles(
+  //         sideTitles: SideTitles(
+  //           showTitles: true,
+  //           reservedSize: 45,
+  //           interval: maxStep / 4,
+  //           getTitlesWidget: (value, meta) {
+  //             return SideTitleWidget(
+  //               axisSide: meta.axisSide,
+  //               space: 5,
+  //               child: Text(
+  //                 NumberFormat('###,###,###').format(value.toInt()),
+  //                 style: TextStyles.fs12w400cTextSecondary,
+  //                 textAlign: TextAlign.center,
+  //               ),
+  //             );
+  //           },
+  //         ),
+  //       ),
+  //     );
+  //
+  // FlBorderData get borderData => FlBorderData(
+  //       show: false,
+  //     );
+  //
+  // List<BarChartGroupData> getBarGroups(steps) {
+  //   List<BarChartGroupData> barChartGroupData = [];
+  //   for (int i = 0; i < steps.length; i++) {
+  //     barChartGroupData.add(
+  //       BarChartGroupData(
+  //         x: i,
+  //         barRods: [
+  //           BarChartRodData(
+  //             width: 16,
+  //             borderRadius: BorderRadius.only(
+  //               topLeft: Radius.circular(6),
+  //               topRight: Radius.circular(6),
+  //             ),
+  //             gradient: LinearGradient(
+  //               colors: [AppColors.primaryGradient, AppColors.primary],
+  //               begin: Alignment.bottomCenter,
+  //               end: Alignment.topCenter,
+  //             ),
+  //             toY: steps[i].toDouble(),
+  //             color: Colors.greenAccent,
+  //           ),
+  //         ],
+  //       ),
+  //     );
+  //   }
+  //   return barChartGroupData;
+  // }
+  //
+  // BarTouchData getBarTouchData() {
+  //   return BarTouchData(
+  //     touchTooltipData: BarTouchTooltipData(
+  //       getTooltipColor: (_) => AppColors.backgroundThird,
+  //       tooltipHorizontalAlignment: FLHorizontalAlignment.center,
+  //       tooltipMargin: -10,
+  //       getTooltipItem: (group, groupIndex, rod, rodIndex) {
+  //         return BarTooltipItem(
+  //           (rod.toY).toInt().toString(),
+  //           TextStyles.fs17w600cTextPrimary,
+  //         );
+  //       },
+  //     ),
+  //     touchCallback: (FlTouchEvent event, barTouchResponse) {
+  //       if (!event.isInterestedForInteractions ||
+  //           barTouchResponse == null ||
+  //           barTouchResponse.spot == null) {
+  //         return;
+  //       }
+  //     },
+  //   );
+  // }
+}


### PR DESCRIPTION
## 작업 내용*
- 프론트에서 걸음 수 관련 코드를 주석처리함

## 고민한 내용*
- UI에서 걸음수를 표시하는 위젯들은 통째로 복사한 후 코드를 주석처리하여 제거
- 로직 관련 코드는 초기화하는 코드를 주석처리함

## 결과 
- 백그라운드에서 '걸음 상태'는 정상 작동
- 마이페이지에서 걸음 수 차트를 빈 위젯으로 대체

커밋 꼭 봐주세요!!