### PR TITLE
M3-407 이벤트 팝업 띄우는 팝업창 구현 및 공지사항 화면 구현

### DIFF
--- a/lib/constants/text_styles.dart
+++ b/lib/constants/text_styles.dart
@@ -87,6 +87,12 @@ class TextStyles {
     fontWeight: FontWeight.w800,
   );
 
+  static TextStyle fs12w800cTextPrimary = TextStyle(
+    color: AppColors.textPrimary,
+    fontSize: 12,
+    fontWeight: FontWeight.w800,
+  );
+
   static TextStyle fs15w800cTextPrimary = TextStyle(
     color: AppColors.textPrimary,
     fontSize: 15,
@@ -162,6 +168,12 @@ class TextStyles {
   static TextStyle fs17w700cTextBlack = TextStyle(
     color: AppColors.textBlack,
     fontSize: 17,
+    fontWeight: FontWeight.w700,
+  );
+
+  static TextStyle fs16w700cTextPrimary = TextStyle(
+    color: AppColors.textPrimary,
+    fontSize: 16,
     fontWeight: FontWeight.w700,
   );
 }

--- a/lib/controllers/announcement_controller.dart
+++ b/lib/controllers/announcement_controller.dart
@@ -13,7 +13,10 @@ class AnnouncementController extends GetxController {
   final ScrollController scrollController = ScrollController();
   final AnnouncementService announcementService = AnnouncementService();
   final Announcement announcement = Announcement(
-      title: 'V1.0.6 업데이트 공지', announcementId: 1, date: DateTime.now());
+    title: 'V1.0.6 업데이트 공지',
+    announcementId: 1,
+    date: DateTime.now(),
+  );
 
   @override
   void onInit() {
@@ -54,10 +57,13 @@ class AnnouncementController extends GetxController {
   showAnnouncement(int announcementId) async {
     AnnouncementInfo announcement =
         await announcementService.getAnnouncementContent(announcementId);
-    Get.to(AnnouncementScreen(
+    Get.to(
+      AnnouncementScreen(
         title: announcement.title,
         date: announcement.date,
-        content: announcement.content));
+        content: announcement.content,
+      ),
+    );
   }
 
   @override

--- a/lib/controllers/announcement_controller.dart
+++ b/lib/controllers/announcement_controller.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/cupertino.dart';
+import 'package:get/get.dart';
+
+import '../models/announcement.dart';
+import '../service/announcement_service.dart';
+import '../widgets/announcement/announcement_element.dart';
+
+class AnnouncementController extends GetxController {
+  var items = <AnnouncementElement>[].obs; // 관찰 가능한 리스트
+  var isLoading = false.obs; // 로딩 상태 관리
+  final ScrollController scrollController = ScrollController();
+  final AnnouncementService announcementService = AnnouncementService();
+  final Announcement announcement = Announcement(
+      title: 'V1.0.6 업데이트 공지', announcementId: 1, date: DateTime.now());
+
+  @override
+  void onInit() {
+    super.onInit();
+    loadInitialItems(); // 초기 데이터 로드
+    scrollController.addListener(_onScroll); // 스크롤 이벤트 리스너 추가
+  }
+
+  Future<void> loadInitialItems() async {
+    final List<Announcement> announcements =
+        await announcementService.getAnnouncements(0);
+    final List<AnnouncementElement> newItems = announcements
+        .map((announcement) => AnnouncementElement(announcement: announcement))
+        .toList();
+
+    items.addAll(newItems); // 초기 20개 항목 로드
+  }
+
+  void _onScroll() {
+    if (scrollController.position.pixels >=
+            scrollController.position.maxScrollExtent - 200 &&
+        !isLoading.value) {
+      fetchMoreItems();
+    }
+  }
+
+  Future<void> fetchMoreItems() async {
+    isLoading.value = true;
+    final List<Announcement> announcements =
+        await announcementService.getAnnouncements(0);
+    final List<AnnouncementElement> newItems = announcements
+        .map((announcement) => AnnouncementElement(announcement: announcement))
+        .toList();
+    items.addAll(newItems);
+    isLoading.value = false;
+  }
+
+  @override
+  void onClose() {
+    scrollController.dispose();
+    super.onClose();
+  }
+}

--- a/lib/controllers/announcement_controller.dart
+++ b/lib/controllers/announcement_controller.dart
@@ -2,6 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 
 import '../models/announcement.dart';
+import '../models/announcement_info.dart';
+import '../screens/announcement_screen.dart';
 import '../service/announcement_service.dart';
 import '../widgets/announcement/announcement_element.dart';
 
@@ -47,6 +49,15 @@ class AnnouncementController extends GetxController {
         .toList();
     items.addAll(newItems);
     isLoading.value = false;
+  }
+
+  showAnnouncement(int announcementId) async {
+    AnnouncementInfo announcement =
+        await announcementService.getAnnouncementContent(announcementId);
+    Get.to(AnnouncementScreen(
+        title: announcement.title,
+        date: announcement.date,
+        content: announcement.content));
   }
 
   @override

--- a/lib/controllers/announcement_controller.dart
+++ b/lib/controllers/announcement_controller.dart
@@ -33,7 +33,9 @@ class AnnouncementController extends GetxController {
     final List<AnnouncementElement> newItems = announcements
         .map((announcement) => AnnouncementElement(announcement: announcement))
         .toList();
-    lastItemIndex = announcements[announcements.length - 1].announcementId;
+    if (announcements.isNotEmpty) {
+      lastItemIndex = announcements[announcements.length - 1].announcementId;
+    }
     items.addAll(newItems);
   }
 
@@ -52,7 +54,10 @@ class AnnouncementController extends GetxController {
     final List<AnnouncementElement> newItems = announcements
         .map((announcement) => AnnouncementElement(announcement: announcement))
         .toList();
-    lastItemIndex = announcements[announcements.length - 1].announcementId;
+    if (announcements.isNotEmpty) {
+      lastItemIndex = announcements[announcements.length - 1].announcementId;
+    }
+
     items.addAll(newItems);
     isLoading.value = false;
   }

--- a/lib/controllers/announcement_controller.dart
+++ b/lib/controllers/announcement_controller.dart
@@ -8,8 +8,10 @@ import '../service/announcement_service.dart';
 import '../widgets/announcement/announcement_element.dart';
 
 class AnnouncementController extends GetxController {
-  var items = <AnnouncementElement>[].obs; // 관찰 가능한 리스트
-  var isLoading = false.obs; // 로딩 상태 관리
+  var items = <AnnouncementElement>[].obs;
+  var isLoading = false.obs;
+  var lastItemIndex = 0;
+
   final ScrollController scrollController = ScrollController();
   final AnnouncementService announcementService = AnnouncementService();
   final Announcement announcement = Announcement(
@@ -21,18 +23,18 @@ class AnnouncementController extends GetxController {
   @override
   void onInit() {
     super.onInit();
-    loadInitialItems(); // 초기 데이터 로드
-    scrollController.addListener(_onScroll); // 스크롤 이벤트 리스너 추가
+    loadInitialItems();
+    scrollController.addListener(_onScroll);
   }
 
   Future<void> loadInitialItems() async {
     final List<Announcement> announcements =
-        await announcementService.getAnnouncements(0);
+        await announcementService.getAnnouncements(lastItemIndex);
     final List<AnnouncementElement> newItems = announcements
         .map((announcement) => AnnouncementElement(announcement: announcement))
         .toList();
-
-    items.addAll(newItems); // 초기 20개 항목 로드
+    lastItemIndex = announcements[announcements.length - 1].announcementId;
+    items.addAll(newItems);
   }
 
   void _onScroll() {
@@ -46,10 +48,11 @@ class AnnouncementController extends GetxController {
   Future<void> fetchMoreItems() async {
     isLoading.value = true;
     final List<Announcement> announcements =
-        await announcementService.getAnnouncements(0);
+        await announcementService.getAnnouncements(lastItemIndex);
     final List<AnnouncementElement> newItems = announcements
         .map((announcement) => AnnouncementElement(announcement: announcement))
         .toList();
+    lastItemIndex = announcements[announcements.length - 1].announcementId;
     items.addAll(newItems);
     isLoading.value = false;
   }

--- a/lib/controllers/main_controller.dart
+++ b/lib/controllers/main_controller.dart
@@ -6,7 +6,6 @@ import 'package:permission_handler/permission_handler.dart';
 
 import '../constants/app_colors.dart';
 import '../constants/text_styles.dart';
-import '../service/android_walking_service.dart';
 import '../service/fcm_service.dart';
 import '../service/my_place_service.dart';
 
@@ -23,8 +22,7 @@ class MainController extends GetxController {
     super.onInit();
     fcmService.registerFcmToken();
     myPlaceService.getMyPlaceInfo();
-    await AndroidWalkingService().postAllUserStepFromStorage();
-    checkNewFeature();
+    // await AndroidWalkingService().postAllUserStepFromStorage();
     await checkLocationPermission();
     await checkBatteryPermission();
   }
@@ -45,14 +43,6 @@ class MainController extends GetxController {
         await OptimizeBattery.isIgnoringBatteryOptimizations();
     if (batteryPermissionGranted == false) {
       _showRequestBattery();
-    }
-  }
-
-  void checkNewFeature() {
-    bool? isChecked = storage.read('group_feature_checked');
-    if (isChecked == null) {
-      storage.write('group_feature_checked', true);
-      _showNewFeature();
     }
   }
 

--- a/lib/controllers/main_controller.dart
+++ b/lib/controllers/main_controller.dart
@@ -54,7 +54,6 @@ class MainController extends GetxController {
   }
 
   loadEvent() async {
-    print('-------------------------------------------event');
     final popupData = await SecureStorage().secureStorage.read(key: popupKey);
     if (popupData == null ||
         popupData != DateTime.now().toString().split(" ")[0]) {
@@ -146,40 +145,6 @@ class MainController extends GetxController {
             ),
             onPressed: () async {
               await OptimizeBattery.stopOptimizingBatteryUsage();
-              Get.back();
-            },
-          ),
-        ],
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
-        ),
-        backgroundColor: AppColors.boxColor,
-      ),
-    );
-  }
-
-  void _showNewFeature() {
-    Get.dialog(
-      AlertDialog(
-        title: Text(
-          '그룹 기능 출시!',
-          style: TextStyle(
-            color: AppColors.textPrimary,
-            fontSize: 20,
-            fontWeight: FontWeight.w400,
-          ),
-        ),
-        content: Text(
-          '이제 그룹원들과 함께 점령할 수 있어요! 지금 바로 원하는 그룹에 가입해서 그룹의 랭킹을 높여보세요!!',
-          style: TextStyles.fs17w400cTextSecondary,
-        ),
-        actions: [
-          TextButton(
-            child: Text(
-              '닫기',
-              style: TextStyles.fs17w700cPrimary,
-            ),
-            onPressed: () async {
               Get.back();
             },
           ),

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -53,6 +53,7 @@ class MapController extends SuperController {
   static const double latPerPixel = 0.000724;
   static const double lonPerPixel = 0.000909;
   static const String backgroundModeStatusKey = 'backgroundModeStatusKey';
+  static const String firstLaunchKey = 'firstLaunchKey';
 
   late final String mapStyle;
 
@@ -100,6 +101,7 @@ class MapController extends SuperController {
     latestPixel = {'x': 0, 'y': 0};
     await updateCurrentPixel();
     updateMap();
+    _occupyFirstPixel();
     _trackUserLocation();
     trackPixels();
     lastOnTabPixel = Pixel.createEmptyPixel();
@@ -130,6 +132,17 @@ class MapController extends SuperController {
 
   onBottomBarHidden() {
     bottomSheetController.minimize();
+  }
+
+  _occupyFirstPixel() async {
+    String? isFirstLaunch =
+        await SecureStorage().secureStorage.read(key: firstLaunchKey);
+    if (isFirstLaunch == null) {
+      occupyPixel();
+      await SecureStorage()
+          .secureStorage
+          .write(key: firstLaunchKey, value: 'false');
+    }
   }
 
   loadEvent() async {

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -11,10 +11,12 @@ import 'package:wakelock_plus/wakelock_plus.dart';
 import '../constants/app_colors.dart';
 import '../enums/pixel_mode.dart';
 import '../models/community_mode_pixel.dart';
+import '../models/event.dart';
 import '../models/individual_history_pixel.dart';
 import '../models/individual_mode_pixel.dart';
 import '../models/region.dart';
 import '../models/user_pixel_count.dart';
+import '../service/announcement_service.dart';
 import '../service/community_service.dart';
 import '../service/location_service.dart';
 import '../service/pixel_service.dart';
@@ -38,6 +40,7 @@ class MapController extends SuperController {
   final LocationService _locationService = LocationService();
   final WalkingService walkingService =
       WalkingServiceFactory.getWalkingService();
+  final AnnouncementService announcementService = AnnouncementService();
 
   final BottomSheetController bottomSheetController =
       Get.find<BottomSheetController>();
@@ -131,15 +134,22 @@ class MapController extends SuperController {
     final popupData = await SecureStorage().secureStorage.read(key: popupKey);
     if (popupData == null ||
         popupData != DateTime.now().toString().split(" ")[0]) {
+      List<Event> events = await announcementService.getEvents();
+
+      if (events.isEmpty) {
+        return;
+      }
       Get.bottomSheet(
-        EventPopUp(),
+        EventPopUp(events: events),
         backgroundColor: AppColors.backgroundSecondary,
       );
     }
   }
 
   setDoNotShowToday() async {
-    await SecureStorage().secureStorage.write(key: popupKey, value: DateTime.now().toString().split(" ")[0]);
+    await SecureStorage()
+        .secureStorage
+        .write(key: popupKey, value: DateTime.now().toString().split(" ")[0]);
   }
 
   updateCurrentPixel() async {

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -20,9 +20,11 @@ import '../service/location_service.dart';
 import '../service/pixel_service.dart';
 import '../service/user_service.dart';
 import '../utils/date_handler.dart';
+import '../utils/secure_storage.dart';
 import '../utils/user_manager.dart';
 import '../utils/walking_service.dart';
 import '../utils/walking_service_factory.dart';
+import '../widgets/common/event_pop_up/pop_up_event.dart';
 import '../widgets/map/filter_bottom_sheet.dart';
 import '../widgets/pixel.dart';
 import 'bottom_sheet_controller.dart';
@@ -39,6 +41,7 @@ class MapController extends SuperController {
 
   final BottomSheetController bottomSheetController =
       Get.find<BottomSheetController>();
+  final String popupKey = "hidePopupUntil";
 
   static const String darkMapStylePath =
       'assets/map_style/dark_map_style_with_landmarks.txt';
@@ -96,6 +99,7 @@ class MapController extends SuperController {
     _trackUserLocation();
     trackPixels();
     lastOnTabPixel = Pixel.createEmptyPixel();
+    loadEvent();
   }
 
   @override
@@ -121,6 +125,21 @@ class MapController extends SuperController {
 
   onBottomBarHidden() {
     bottomSheetController.minimize();
+  }
+
+  loadEvent() async {
+    final popupData = await SecureStorage().secureStorage.read(key: popupKey);
+    if (popupData == null ||
+        popupData != DateTime.now().toString().split(" ")[0]) {
+      Get.bottomSheet(
+        EventPopUp(),
+        backgroundColor: AppColors.backgroundSecondary,
+      );
+    }
+  }
+
+  setDoNotShowToday() async {
+    await SecureStorage().secureStorage.write(key: popupKey, value: DateTime.now().toString().split(" ")[0]);
   }
 
   updateCurrentPixel() async {
@@ -582,7 +601,8 @@ class MapController extends SuperController {
 
   void changeBackgroundMode(bool changedValue) async {
     if (changedValue) {
-      bool isLocationAlwaysEnabled = await Get.find<MainController>().checkLocationPermission();
+      bool isLocationAlwaysEnabled =
+          await Get.find<MainController>().checkLocationPermission();
       if (!isLocationAlwaysEnabled) {
         return;
       }

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -11,12 +11,10 @@ import 'package:wakelock_plus/wakelock_plus.dart';
 import '../constants/app_colors.dart';
 import '../enums/pixel_mode.dart';
 import '../models/community_mode_pixel.dart';
-import '../models/event.dart';
 import '../models/individual_history_pixel.dart';
 import '../models/individual_mode_pixel.dart';
 import '../models/region.dart';
 import '../models/user_pixel_count.dart';
-import '../service/announcement_service.dart';
 import '../service/community_service.dart';
 import '../service/location_service.dart';
 import '../service/pixel_service.dart';
@@ -26,7 +24,6 @@ import '../utils/secure_storage.dart';
 import '../utils/user_manager.dart';
 import '../utils/walking_service.dart';
 import '../utils/walking_service_factory.dart';
-import '../widgets/common/event_pop_up/pop_up_event.dart';
 import '../widgets/map/filter_bottom_sheet.dart';
 import '../widgets/pixel.dart';
 import 'bottom_sheet_controller.dart';
@@ -40,11 +37,9 @@ class MapController extends SuperController {
   final LocationService _locationService = LocationService();
   final WalkingService walkingService =
       WalkingServiceFactory.getWalkingService();
-  final AnnouncementService announcementService = AnnouncementService();
 
   final BottomSheetController bottomSheetController =
       Get.find<BottomSheetController>();
-  final String popupKey = "hidePopupUntil";
 
   static const String darkMapStylePath =
       'assets/map_style/dark_map_style_with_landmarks.txt';
@@ -106,7 +101,6 @@ class MapController extends SuperController {
     trackPixels();
     lastOnTabPixel = Pixel.createEmptyPixel();
     _loadBackgroundModeStatus();
-    loadEvent();
   }
 
   @override
@@ -143,28 +137,6 @@ class MapController extends SuperController {
           .secureStorage
           .write(key: firstLaunchKey, value: 'false');
     }
-  }
-
-  loadEvent() async {
-    final popupData = await SecureStorage().secureStorage.read(key: popupKey);
-    if (popupData == null ||
-        popupData != DateTime.now().toString().split(" ")[0]) {
-      List<Event> events = await announcementService.getEvents();
-
-      if (events.isEmpty) {
-        return;
-      }
-      Get.bottomSheet(
-        EventPopUp(events: events),
-        backgroundColor: AppColors.backgroundSecondary,
-      );
-    }
-  }
-
-  setDoNotShowToday() async {
-    await SecureStorage()
-        .secureStorage
-        .write(key: popupKey, value: DateTime.now().toString().split(" ")[0]);
   }
 
   updateCurrentPixel() async {

--- a/lib/models/announcement.dart
+++ b/lib/models/announcement.dart
@@ -1,0 +1,33 @@
+class Announcement {
+  final String title;
+  final int announcementId;
+  final DateTime date;
+
+  Announcement({
+    required this.title,
+    required this.announcementId,
+    required this.date,
+  });
+
+  factory Announcement.fromJson(Map<String, dynamic> json) {
+    return switch (json) {
+      {
+        'title': var title,
+        'announcementId': var announcementId,
+        'date': var date,
+      } =>
+        Announcement(
+          title: title,
+          announcementId: announcementId,
+          date: DateTime.parse(date),
+        ),
+      _ => throw const FormatException('Failed to load Announcement')
+    };
+  }
+
+  static List<Announcement> listFromJson(List<dynamic> jsonList) {
+    return [
+      for (var element in jsonList) Announcement.fromJson(element),
+    ];
+  }
+}

--- a/lib/models/announcement.dart
+++ b/lib/models/announcement.dart
@@ -14,7 +14,7 @@ class Announcement {
       {
         'title': var title,
         'announcementId': var announcementId,
-        'date': var date,
+        'createdAt': var date,
       } =>
         Announcement(
           title: title,

--- a/lib/models/announcement_info.dart
+++ b/lib/models/announcement_info.dart
@@ -20,10 +20,11 @@ class AnnouncementInfo {
         'content': var content,
       } =>
         AnnouncementInfo(
-            title: title,
-            announcementId: announcementId,
-            date: DateTime.parse(date),
-            content: content),
+          title: title,
+          announcementId: announcementId,
+          date: DateTime.parse(date),
+          content: content,
+        ),
       _ => throw const FormatException('Failed to load Announcement')
     };
   }

--- a/lib/models/announcement_info.dart
+++ b/lib/models/announcement_info.dart
@@ -1,0 +1,36 @@
+class AnnouncementInfo {
+  final String title;
+  final int announcementId;
+  final DateTime date;
+  final String content;
+
+  AnnouncementInfo({
+    required this.title,
+    required this.announcementId,
+    required this.date,
+    required this.content,
+  });
+
+  factory AnnouncementInfo.fromJson(Map<String, dynamic> json) {
+    return switch (json) {
+      {
+        'title': var title,
+        'announcementId': var announcementId,
+        'createdAt': var date,
+        'content': var content,
+      } =>
+        AnnouncementInfo(
+            title: title,
+            announcementId: announcementId,
+            date: DateTime.parse(date),
+            content: content),
+      _ => throw const FormatException('Failed to load Announcement')
+    };
+  }
+
+  static List<AnnouncementInfo> listFromJson(List<dynamic> jsonList) {
+    return [
+      for (var element in jsonList) AnnouncementInfo.fromJson(element),
+    ];
+  }
+}

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -1,21 +1,25 @@
 class Event {
   final String eventImageUrl;
   final int? announcementId;
+  final int eventId;
 
   Event({
     required this.eventImageUrl,
     required this.announcementId,
+    required this.eventId,
   });
 
   factory Event.fromJson(Map<String, dynamic> json) {
     return switch (json) {
       {
         'eventImageUrl': var eventImageUrl,
-        'announcementId': var eventId,
+        'announcementId': var announcementId,
+        'eventId': var eventId,
       } =>
         Event(
           eventImageUrl: eventImageUrl,
-          announcementId: eventId,
+          announcementId: announcementId,
+          eventId: eventId,
         ),
       _ => throw const FormatException('Failed to load Pixel')
     };

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -1,0 +1,29 @@
+class Event {
+  final String eventImageUrl;
+  final int? announcementId;
+
+  Event({
+    required this.eventImageUrl,
+    required this.announcementId,
+  });
+
+  factory Event.fromJson(Map<String, dynamic> json) {
+    return switch (json) {
+      {
+        'eventImageUrl': var eventImageUrl,
+        'announcementId': var eventId,
+      } =>
+        Event(
+          eventImageUrl: eventImageUrl,
+          announcementId: eventId,
+        ),
+      _ => throw const FormatException('Failed to load Pixel')
+    };
+  }
+
+  static List<Event> listFromJson(List<dynamic> jsonList) {
+    return [
+      for (var element in jsonList) Event.fromJson(element),
+    ];
+  }
+}

--- a/lib/screens/announcement_list_screen.dart
+++ b/lib/screens/announcement_list_screen.dart
@@ -33,24 +33,28 @@ class AnnouncementListScreen extends StatelessWidget {
       body: Column(
         children: [
           Expanded(
-            child: Obx(() => Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 25.0),
-                  child: ListView.builder(
-                    controller: controller.scrollController,
-                    itemCount: controller.items.length + 1,
-                    itemBuilder: (context, index) {
-                      if (index < controller.items.length) {
-                        return controller.items[index];
-                      } else {
-                        return Center(
-                          child: controller.isLoading.value
-                              ? CircularProgressIndicator()
-                              : SizedBox.shrink(),
-                        );
-                      }
-                    },
-                  ),
-                ),),
+            child: Obx(
+              () => Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 25.0),
+                child: ListView.builder(
+                  controller: controller.scrollController,
+                  itemCount: controller.items.length + 1,
+                  itemBuilder: (context, index) {
+                    if (index < controller.items.length) {
+                      return controller.items[index];
+                    } else {
+                      return Center(
+                        child: controller.isLoading.value
+                            ? CircularProgressIndicator(
+                                color: AppColors.primary,
+                              )
+                            : SizedBox.shrink(),
+                      );
+                    }
+                  },
+                ),
+              ),
+            ),
           ),
         ],
       ),

--- a/lib/screens/announcement_list_screen.dart
+++ b/lib/screens/announcement_list_screen.dart
@@ -50,7 +50,7 @@ class AnnouncementListScreen extends StatelessWidget {
                       }
                     },
                   ),
-                )),
+                ),),
           ),
         ],
       ),

--- a/lib/screens/announcement_list_screen.dart
+++ b/lib/screens/announcement_list_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../constants/app_colors.dart';
+import '../controllers/announcement_controller.dart';
+import '../widgets/common/app_bar.dart';
+
+class AnnouncementListScreen extends StatelessWidget {
+  AnnouncementListScreen({super.key});
+
+  final AnnouncementController controller = Get.put(AnnouncementController());
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        title: AppBarTitle(
+          title: '공지사항',
+        ),
+        leadingWidth: 40,
+        leading: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10.0),
+          child: IconButton(
+            icon: Icon(Icons.arrow_back_ios, color: Colors.white),
+            onPressed: () {
+              Get.back();
+            },
+          ),
+        ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Obx(() => Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 25.0),
+                  child: ListView.builder(
+                    controller: controller.scrollController,
+                    itemCount: controller.items.length + 1,
+                    itemBuilder: (context, index) {
+                      if (index < controller.items.length) {
+                        return controller.items[index];
+                      } else {
+                        return Center(
+                          child: controller.isLoading.value
+                              ? CircularProgressIndicator()
+                              : SizedBox.shrink(),
+                        );
+                      }
+                    },
+                  ),
+                )),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/announcement_screen.dart
+++ b/lib/screens/announcement_screen.dart
@@ -16,7 +16,7 @@ class AnnouncementScreen extends StatelessWidget {
       {super.key,
       required this.title,
       required this.date,
-      required this.content});
+      required this.content,});
 
   @override
   Widget build(BuildContext context) {
@@ -54,23 +54,23 @@ class AnnouncementScreen extends StatelessWidget {
           data: content,
           styleSheet: MarkdownStyleSheet(
             h1: TextStyle(
-                fontSize: 24, fontWeight: FontWeight.bold, color: Colors.white),
+                fontSize: 24, fontWeight: FontWeight.bold, color: Colors.white,),
             h2: TextStyle(
-                fontSize: 22, fontWeight: FontWeight.bold, color: Colors.white),
+                fontSize: 22, fontWeight: FontWeight.bold, color: Colors.white,),
             h3: TextStyle(
-                fontSize: 20, fontWeight: FontWeight.bold, color: Colors.white),
+                fontSize: 20, fontWeight: FontWeight.bold, color: Colors.white,),
             h4: TextStyle(
-                fontSize: 18, fontWeight: FontWeight.bold, color: Colors.white),
+                fontSize: 18, fontWeight: FontWeight.bold, color: Colors.white,),
             h5: TextStyle(
-                fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
+                fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white,),
             h6: TextStyle(
-                fontSize: 14, fontWeight: FontWeight.bold, color: Colors.white),
+                fontSize: 14, fontWeight: FontWeight.bold, color: Colors.white,),
 
             p: TextStyle(fontSize: 16, color: Colors.white),
             strong: TextStyle(
-                fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
+                fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white,),
             em: TextStyle(
-                fontSize: 16, fontStyle: FontStyle.italic, color: Colors.white),
+                fontSize: 16, fontStyle: FontStyle.italic, color: Colors.white,),
 
             blockquote: TextStyle(
               fontSize: 16,
@@ -87,16 +87,16 @@ class AnnouncementScreen extends StatelessWidget {
             code: TextStyle(
                 fontSize: 16,
                 fontFamily: 'monospace',
-                color: Colors.yellowAccent),
+                color: Colors.yellowAccent,),
 
             a: TextStyle(
                 fontSize: 16,
                 color: AppColors.primary,
-                decoration: TextDecoration.underline),
+                decoration: TextDecoration.underline,),
             del: TextStyle(
                 fontSize: 16,
                 color: Colors.red,
-                decoration: TextDecoration.lineThrough),
+                decoration: TextDecoration.lineThrough,),
 
             listBullet: TextStyle(fontSize: 16, color: Colors.white),
             listIndent: 24.0,
@@ -104,7 +104,7 @@ class AnnouncementScreen extends StatelessWidget {
             blockSpacing: 8.0,
             // 각 블록 사이의 간격
             horizontalRuleDecoration: BoxDecoration(
-                border: Border(top: BorderSide(color: Colors.grey))),
+                border: Border(top: BorderSide(color: Colors.grey)),),
 
             textAlign: WrapAlignment.start,
             // textScaleFactor: 1.0,

--- a/lib/screens/announcement_screen.dart
+++ b/lib/screens/announcement_screen.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../constants/app_colors.dart';
+import '../constants/text_styles.dart';
+
+class AnnouncementScreen extends StatelessWidget {
+  final String title;
+  final DateTime date;
+  final String content;
+
+  const AnnouncementScreen(
+      {super.key,
+      required this.title,
+      required this.date,
+      required this.content});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: TextStyles.fs20w600cTextPrimary,
+            ),
+            Text(
+              DateFormat('yyyy.MM.dd').format(date),
+              style: TextStyle(fontSize: 14, color: Colors.white70),
+            ),
+          ],
+        ),
+        leadingWidth: 40,
+        leading: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10.0),
+          child: IconButton(
+            icon: Icon(Icons.arrow_back_ios, color: Colors.white),
+            onPressed: () {
+              Get.back();
+            },
+          ),
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: Markdown(
+          data: content,
+          styleSheet: MarkdownStyleSheet(
+            h1: TextStyle(
+                fontSize: 24, fontWeight: FontWeight.bold, color: Colors.white),
+            h2: TextStyle(
+                fontSize: 22, fontWeight: FontWeight.bold, color: Colors.white),
+            h3: TextStyle(
+                fontSize: 20, fontWeight: FontWeight.bold, color: Colors.white),
+            h4: TextStyle(
+                fontSize: 18, fontWeight: FontWeight.bold, color: Colors.white),
+            h5: TextStyle(
+                fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
+            h6: TextStyle(
+                fontSize: 14, fontWeight: FontWeight.bold, color: Colors.white),
+
+            p: TextStyle(fontSize: 16, color: Colors.white),
+            strong: TextStyle(
+                fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
+            em: TextStyle(
+                fontSize: 16, fontStyle: FontStyle.italic, color: Colors.white),
+
+            blockquote: TextStyle(
+              fontSize: 16,
+              color: Colors.white,
+              fontStyle: FontStyle.italic,
+            ),
+            blockquotePadding: EdgeInsets.all(12),
+            blockquoteDecoration: BoxDecoration(
+              color: Colors.grey.shade800, // 어두운 회색 배경
+              border: Border(
+                left: BorderSide(color: AppColors.primary, width: 4),
+              ),
+            ),
+            code: TextStyle(
+                fontSize: 16,
+                fontFamily: 'monospace',
+                color: Colors.yellowAccent),
+
+            a: TextStyle(
+                fontSize: 16,
+                color: AppColors.primary,
+                decoration: TextDecoration.underline),
+            del: TextStyle(
+                fontSize: 16,
+                color: Colors.red,
+                decoration: TextDecoration.lineThrough),
+
+            listBullet: TextStyle(fontSize: 16, color: Colors.white),
+            listIndent: 24.0,
+
+            blockSpacing: 8.0,
+            // 각 블록 사이의 간격
+            horizontalRuleDecoration: BoxDecoration(
+                border: Border(top: BorderSide(color: Colors.grey))),
+
+            textAlign: WrapAlignment.start,
+            // textScaleFactor: 1.0,
+            checkbox: TextStyle(color: Colors.lightGreenAccent, fontSize: 16),
+          ),
+          onTapLink: (text, url, title) {
+            if (url != null) {
+              launchUrl(Uri.parse(url));
+            }
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -11,6 +11,7 @@ import '../controllers/setting_controller.dart';
 import '../widgets/common/app_bar.dart';
 import '../widgets/setting/setting_item.dart';
 import '../widgets/setting/setting_section.dart';
+import 'announcement_list_screen.dart';
 import 'push_setting_screen.dart';
 
 class SettingScreen extends StatelessWidget {
@@ -84,7 +85,7 @@ class SettingScreen extends StatelessWidget {
                 SettingsItem(
                   title: '공지사항',
                   onTap: () async {
-                    launchUrl(Uri.parse(announcementUrl));
+                    Get.to(AnnouncementListScreen());
                   },
                 ),
                 SettingsItem(

--- a/lib/service/announcement_service.dart
+++ b/lib/service/announcement_service.dart
@@ -17,8 +17,12 @@ class AnnouncementService {
   }
 
   Future<List<Event>> getEvents() async {
-    var response = await dio.get('/announcement/events');
-    return Event.listFromJson(response.data['data']);
+    try {
+      var response = await dio.get('/announcement/events');
+      return Event.listFromJson(response.data['data']);
+    } catch (e) {
+      return [];
+    }
   }
 
   Future<List<Announcement>> getAnnouncements(int cursor) async {

--- a/lib/service/announcement_service.dart
+++ b/lib/service/announcement_service.dart
@@ -41,4 +41,14 @@ class AnnouncementService {
     );
     return AnnouncementInfo.fromJson(response.data['data']);
   }
+
+  Future<void> increaseEventViewCount(int eventId) async {
+    try {
+      await dio.get(
+        '/announcement/events/$eventId/views',
+      );
+    } catch (e) {
+      return;
+    }
+  }
 }

--- a/lib/service/announcement_service.dart
+++ b/lib/service/announcement_service.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 
 import '../models/announcement.dart';
+import '../models/announcement_info.dart';
 import '../models/event.dart';
 import '../utils/dio_service.dart';
 
@@ -28,5 +29,12 @@ class AnnouncementService {
       },
     );
     return Announcement.listFromJson(response.data['data']);
+  }
+
+  Future<AnnouncementInfo> getAnnouncementContent(int announcementId) async {
+    var response = await dio.get(
+      '/announcement/$announcementId',
+    );
+    return AnnouncementInfo.fromJson(response.data['data']);
   }
 }

--- a/lib/service/announcement_service.dart
+++ b/lib/service/announcement_service.dart
@@ -1,0 +1,21 @@
+import 'package:dio/dio.dart';
+
+import '../models/event.dart';
+import '../utils/dio_service.dart';
+
+class AnnouncementService {
+  static final AnnouncementService _instance = AnnouncementService._internal();
+
+  final Dio dio = DioService().getDio();
+
+  AnnouncementService._internal();
+
+  factory AnnouncementService() {
+    return _instance;
+  }
+
+  Future<List<Event>> getEvents() async {
+    var response = await dio.get('/announcement/events');
+    return Event.listFromJson(response.data['data']);
+  }
+}

--- a/lib/service/announcement_service.dart
+++ b/lib/service/announcement_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 
+import '../models/announcement.dart';
 import '../models/event.dart';
 import '../utils/dio_service.dart';
 
@@ -17,5 +18,15 @@ class AnnouncementService {
   Future<List<Event>> getEvents() async {
     var response = await dio.get('/announcement/events');
     return Event.listFromJson(response.data['data']);
+  }
+
+  Future<List<Announcement>> getAnnouncements(int cursor) async {
+    var response = await dio.get(
+      '/announcement',
+      queryParameters: {
+        "cursor": cursor,
+      },
+    );
+    return Announcement.listFromJson(response.data['data']);
   }
 }

--- a/lib/widgets/announcement/announcement_element.dart
+++ b/lib/widgets/announcement/announcement_element.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../constants/app_colors.dart';
+import '../../constants/text_styles.dart';
+import '../../models/announcement.dart';
+
+class AnnouncementElement extends StatelessWidget {
+  final Announcement announcement;
+
+  const AnnouncementElement({super.key, required this.announcement});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Text(
+            announcement.title,
+            style: TextStyles.fs17w700cTextPrimary,
+          ),
+        ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Text(
+            DateFormat('yyyy.MM.dd').format(announcement.date),
+            style: TextStyle(fontSize: 14, color: Colors.white70),
+          ),
+        ),
+        Divider(
+          height: 20,
+          thickness: 0.3,
+          color: AppColors.textSecondary,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/announcement/announcement_element.dart
+++ b/lib/widgets/announcement/announcement_element.dart
@@ -19,28 +19,34 @@ class AnnouncementElement extends StatelessWidget {
       onTap: () {
         controller.showAnnouncement(announcement.announcementId);
       },
-      child: Column(
-        children: [
-          Align(
-            alignment: Alignment.centerLeft,
-            child: Text(
-              announcement.title,
-              style: TextStyles.fs17w700cTextPrimary,
+      child: Container(
+        width: 800,
+        color: Colors.transparent,
+        child: Column(
+          children: [
+            Row(
+              children: [
+                Text(
+                  announcement.title,
+                  style: TextStyles.fs17w700cTextPrimary,
+                ),
+                Spacer(),
+              ],
             ),
-          ),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: Text(
-              DateFormat('yyyy.MM.dd').format(announcement.date),
-              style: TextStyle(fontSize: 14, color: Colors.white70),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                DateFormat('yyyy.MM.dd').format(announcement.date),
+                style: TextStyle(fontSize: 14, color: Colors.white70),
+              ),
             ),
-          ),
-          Divider(
-            height: 20,
-            thickness: 0.3,
-            color: AppColors.textSecondary,
-          ),
-        ],
+            Divider(
+              height: 20,
+              thickness: 0.3,
+              color: AppColors.textSecondary,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/announcement/announcement_element.dart
+++ b/lib/widgets/announcement/announcement_element.dart
@@ -1,39 +1,47 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
+import '../../controllers/announcement_controller.dart';
 import '../../models/announcement.dart';
 
 class AnnouncementElement extends StatelessWidget {
   final Announcement announcement;
+  final AnnouncementController controller = Get.find<AnnouncementController>();
 
-  const AnnouncementElement({super.key, required this.announcement});
+  AnnouncementElement({super.key, required this.announcement});
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Align(
-          alignment: Alignment.centerLeft,
-          child: Text(
-            announcement.title,
-            style: TextStyles.fs17w700cTextPrimary,
+    return GestureDetector(
+      onTap: () {
+        controller.showAnnouncement(announcement.announcementId);
+      },
+      child: Column(
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              announcement.title,
+              style: TextStyles.fs17w700cTextPrimary,
+            ),
           ),
-        ),
-        Align(
-          alignment: Alignment.centerLeft,
-          child: Text(
-            DateFormat('yyyy.MM.dd').format(announcement.date),
-            style: TextStyle(fontSize: 14, color: Colors.white70),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              DateFormat('yyyy.MM.dd').format(announcement.date),
+              style: TextStyle(fontSize: 14, color: Colors.white70),
+            ),
           ),
-        ),
-        Divider(
-          height: 20,
-          thickness: 0.3,
-          color: AppColors.textSecondary,
-        ),
-      ],
+          Divider(
+            height: 20,
+            thickness: 0.3,
+            color: AppColors.textSecondary,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/common/event_pop_up/event_image.dart
+++ b/lib/widgets/common/event_pop_up/event_image.dart
@@ -9,12 +9,14 @@ import '../../../service/announcement_service.dart';
 class EventImage extends StatelessWidget {
   final String imageUrl;
   final int? announcementId;
+  final int eventId;
   final AnnouncementService announcementService = AnnouncementService();
 
   EventImage({
     super.key,
     required this.imageUrl,
     required this.announcementId,
+    required this.eventId,
   });
 
   @override
@@ -22,6 +24,7 @@ class EventImage extends StatelessWidget {
     return GestureDetector(
       onTap: () async {
         if (announcementId != null) {
+          announcementService.increaseEventViewCount(eventId);
           AnnouncementInfo announcement =
               await announcementService.getAnnouncementContent(announcementId!);
           Get.to(

--- a/lib/widgets/common/event_pop_up/event_image.dart
+++ b/lib/widgets/common/event_pop_up/event_image.dart
@@ -1,0 +1,25 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:get/get.dart';
+
+import '../../../screens/setting_screen.dart';
+
+class EventImage extends StatelessWidget {
+  final String imageUrl;
+  final int eventId;
+
+  const EventImage({super.key, required this.imageUrl, required this.eventId});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        Get.to(SettingScreen());
+      },
+      child: Image(
+        image: CachedNetworkImageProvider(imageUrl),
+        fit: BoxFit.cover,
+      ),
+    );
+  }
+}

--- a/lib/widgets/common/event_pop_up/event_image.dart
+++ b/lib/widgets/common/event_pop_up/event_image.dart
@@ -6,9 +6,10 @@ import '../../../screens/setting_screen.dart';
 
 class EventImage extends StatelessWidget {
   final String imageUrl;
-  final int eventId;
+  final int? announcementId;
 
-  const EventImage({super.key, required this.imageUrl, required this.eventId});
+  const EventImage(
+      {super.key, required this.imageUrl, required this.announcementId});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/common/event_pop_up/event_image.dart
+++ b/lib/widgets/common/event_pop_up/event_image.dart
@@ -2,20 +2,36 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 
-import '../../../screens/setting_screen.dart';
+import '../../../models/announcement_info.dart';
+import '../../../screens/announcement_screen.dart';
+import '../../../service/announcement_service.dart';
 
 class EventImage extends StatelessWidget {
   final String imageUrl;
   final int? announcementId;
+  final AnnouncementService announcementService = AnnouncementService();
 
-  const EventImage(
-      {super.key, required this.imageUrl, required this.announcementId});
+  EventImage({
+    super.key,
+    required this.imageUrl,
+    required this.announcementId,
+  });
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {
-        Get.to(SettingScreen());
+      onTap: () async {
+        if (announcementId != null) {
+          AnnouncementInfo announcement =
+              await announcementService.getAnnouncementContent(announcementId!);
+          Get.to(
+            AnnouncementScreen(
+              title: announcement.title,
+              date: announcement.date,
+              content: announcement.content,
+            ),
+          );
+        }
       },
       child: Image(
         image: CachedNetworkImageProvider(imageUrl),

--- a/lib/widgets/common/event_pop_up/pop_up_event.dart
+++ b/lib/widgets/common/event_pop_up/pop_up_event.dart
@@ -40,6 +40,7 @@ class EventPopUp extends StatelessWidget {
                     children: [
                       for (int i = 0; i < events.length; i++)
                         EventImage(
+                          eventId: events[i].eventId,
                           imageUrl: events[i].eventImageUrl,
                           announcementId: events[i].announcementId,
                         ),

--- a/lib/widgets/common/event_pop_up/pop_up_event.dart
+++ b/lib/widgets/common/event_pop_up/pop_up_event.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 
 import '../../../constants/app_colors.dart';
 import '../../../constants/text_styles.dart';
+import '../../../utils/secure_storage.dart';
 import 'event_image.dart';
 
 class EventPopUp extends StatelessWidget {
@@ -59,7 +60,13 @@ class EventPopUp extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     TextButton(
-                      onPressed: () {},
+                      onPressed: () async {
+                        await SecureStorage().secureStorage.write(
+                              key: "hidePopupUntil",
+                              value: DateTime.now().toString().split(" ")[0],
+                            );
+                        Get.back();
+                      },
                       style: TextButton.styleFrom(
                         overlayColor: Colors.grey.withOpacity(0.2),
                       ),

--- a/lib/widgets/common/event_pop_up/pop_up_event.dart
+++ b/lib/widgets/common/event_pop_up/pop_up_event.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../constants/app_colors.dart';
+import '../../../constants/text_styles.dart';
+import 'event_image.dart';
+
+class EventPopUp extends StatelessWidget {
+  const EventPopUp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final PageController pageController = PageController();
+    int currentPage = 0;
+
+    return StatefulBuilder(
+      builder: (BuildContext context, StateSetter setState) {
+        return Container(
+          decoration: BoxDecoration(),
+          height: 380,
+          child: Column(
+            children: [
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.only(
+                    topLeft: Radius.circular(30.0),
+                    topRight: Radius.circular(30.0),
+                  ),
+                  child: PageView(
+                    controller: pageController,
+                    onPageChanged: (index) {
+                      setState(() {
+                        currentPage = index;
+                      });
+                    },
+                    children: [
+                      EventImage(
+                        imageUrl:
+                            "https://ground-flip-prod-storage.s3.ap-northeast-2.amazonaws.com/event/%E1%84%92%E1%85%A1%E1%86%AB%E1%84%80%E1%85%A1%E1%86%BC%E1%84%8B%E1%85%B5%E1%84%87%E1%85%A6%E1%86%AB%E1%84%90%E1%85%B32.png",
+                        eventId: 1,
+                      ),
+                      EventImage(
+                        imageUrl:
+                            "https://s3.ap-northeast-2.amazonaws.com/ground-flip-prod-storage/static/66ade0ab-833f-43d0-811a-7c228dcbebec.jpg",
+                        eventId: 1,
+                      ),
+                      EventImage(
+                        imageUrl:
+                            "https://ground-flip-prod-storage-resized.s3.ap-northeast-2.amazonaws.com/resized-static/da05e0cc-6831-45c6-aeee-2597c5a04d07%23%23%23626.jpg",
+                        eventId: 1,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    TextButton(
+                      onPressed: () {},
+                      style: TextButton.styleFrom(
+                        overlayColor: Colors.grey.withOpacity(0.2),
+                      ),
+                      child: Text(
+                        '오늘 하루 보지 않기',
+                        style: TextStyles.fs14w500cTextSecondary,
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Text(
+                        "${currentPage + 1} / 3", // 현재 페이지 (1부터 시작)와 전체 페이지 수
+                        style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                            color: AppColors.textSecondary),
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        Get.back();
+                      },
+                      style: TextButton.styleFrom(
+                        overlayColor: Colors.grey.withOpacity(0.2),
+                      ),
+                      child: Text(
+                        '닫기',
+                        style: TextStyles.fs14w500cTextSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(
+                height: 30,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/common/event_pop_up/pop_up_event.dart
+++ b/lib/widgets/common/event_pop_up/pop_up_event.dart
@@ -3,11 +3,14 @@ import 'package:get/get.dart';
 
 import '../../../constants/app_colors.dart';
 import '../../../constants/text_styles.dart';
+import '../../../models/event.dart';
 import '../../../utils/secure_storage.dart';
 import 'event_image.dart';
 
 class EventPopUp extends StatelessWidget {
-  const EventPopUp({super.key});
+  final List<Event> events;
+
+  const EventPopUp({super.key, required this.events});
 
   @override
   Widget build(BuildContext context) {
@@ -35,21 +38,11 @@ class EventPopUp extends StatelessWidget {
                       });
                     },
                     children: [
-                      EventImage(
-                        imageUrl:
-                            "https://ground-flip-prod-storage.s3.ap-northeast-2.amazonaws.com/event/%E1%84%92%E1%85%A1%E1%86%AB%E1%84%80%E1%85%A1%E1%86%BC%E1%84%8B%E1%85%B5%E1%84%87%E1%85%A6%E1%86%AB%E1%84%90%E1%85%B32.png",
-                        eventId: 1,
-                      ),
-                      EventImage(
-                        imageUrl:
-                            "https://s3.ap-northeast-2.amazonaws.com/ground-flip-prod-storage/static/66ade0ab-833f-43d0-811a-7c228dcbebec.jpg",
-                        eventId: 1,
-                      ),
-                      EventImage(
-                        imageUrl:
-                            "https://ground-flip-prod-storage-resized.s3.ap-northeast-2.amazonaws.com/resized-static/da05e0cc-6831-45c6-aeee-2597c5a04d07%23%23%23626.jpg",
-                        eventId: 1,
-                      ),
+                      for (int i = 0; i < events.length; i++)
+                        EventImage(
+                          imageUrl: events[i].eventImageUrl,
+                          announcementId: events[i].announcementId,
+                        ),
                     ],
                   ),
                 ),
@@ -78,11 +71,12 @@ class EventPopUp extends StatelessWidget {
                     Padding(
                       padding: const EdgeInsets.all(8.0),
                       child: Text(
-                        "${currentPage + 1} / 3", // 현재 페이지 (1부터 시작)와 전체 페이지 수
+                        "${currentPage + 1} / ${events.length}",
                         style: TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                            color: AppColors.textSecondary),
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                          color: AppColors.textSecondary,
+                        ),
                       ),
                     ),
                     TextButton(

--- a/lib/widgets/my_page/user_info.dart
+++ b/lib/widgets/my_page/user_info.dart
@@ -6,9 +6,15 @@ import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
 import '../../controllers/my_page_controller.dart';
 import '../../screens/user_info_update_screen.dart';
+import '../../utils/user_manager.dart';
 
 class UserInfo extends StatelessWidget {
   const UserInfo({super.key});
+
+  String getEncodedUserId() {
+    String base36 = UserManager().userId!.toRadixString(36).toUpperCase();
+    return base36.padLeft(6, '0');
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -51,15 +57,45 @@ class UserInfo extends StatelessWidget {
                   () => Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        myPageController.getCurrentUserNickname(),
-                        style: TextStyles.fs20w600cTextPrimary,
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Text(
+                            // myPageController.getCurrentUserNickname(),
+                            '가나다라마바사아자차',
+                            style: TextStyles.fs20w600cTextPrimary,
+                          ),
+                          SizedBox(
+                            width: 10,
+                          ),
+                        ],
+                      ),
+                      SelectableText(
+                        '${getEncodedUserId()}',
+                        style: TextStyles.fs14w600cTextSecondary,
                       ),
                       if (myPageController.getCurrentUserCommunityName() !=
                           null)
-                        Text(
-                          myPageController.getCurrentUserCommunityName()!,
-                          style: TextStyles.fs14w400cTextSecondary,
+                        Column(
+                          children: [
+                            SizedBox(
+                              height: 5,
+                            ),
+                            Row(
+                              children: [
+                                Icon(
+                                  Icons.group,
+                                  color: AppColors.primary,
+                                ),
+                                SizedBox(width: 5),
+                                Text(
+                                  myPageController
+                                      .getCurrentUserCommunityName()!,
+                                  style: TextStyles.fs14w500cPrimary,
+                                ),
+                              ],
+                            ),
+                          ],
                         ),
                     ],
                   ),

--- a/lib/widgets/my_page/user_info.dart
+++ b/lib/widgets/my_page/user_info.dart
@@ -61,8 +61,7 @@ class UserInfo extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           Text(
-                            // myPageController.getCurrentUserNickname(),
-                            '가나다라마바사아자차',
+                            myPageController.getCurrentUserNickname(),
                             style: TextStyles.fs20w600cTextPrimary,
                           ),
                           SizedBox(

--- a/lib/widgets/my_page/user_info.dart
+++ b/lib/widgets/my_page/user_info.dart
@@ -67,11 +67,11 @@ class UserInfo extends StatelessWidget {
                           SizedBox(
                             width: 10,
                           ),
+                          SelectableText(
+                            getEncodedUserId(),
+                            style: TextStyles.fs14w600cTextSecondary,
+                          ),
                         ],
-                      ),
-                      SelectableText(
-                        '${getEncodedUserId()}',
-                        style: TextStyles.fs14w600cTextSecondary,
                       ),
                       if (myPageController.getCurrentUserCommunityName() !=
                           null)

--- a/lib/widgets/ranking/ranking_info.dart
+++ b/lib/widgets/ranking/ranking_info.dart
@@ -84,11 +84,22 @@ class Rank extends StatelessWidget {
         height: size,
       );
     } else {
+      Widget rankText;
+      if (rank! > 9999) {
+        rankText =
+            Text(rank.toString(), style: TextStyles.fs12w800cTextPrimary);
+      } else if (rank! > 999) {
+        rankText =
+            Text(rank.toString(), style: TextStyles.fs16w700cTextPrimary);
+      } else {
+        rankText =
+            Text(rank.toString(), style: TextStyles.fs20w800cTextPrimary);
+      }
       return SizedBox(
         width: size,
         height: size,
         child: Center(
-          child: Text(rank.toString(), style: TextStyles.fs20w800cTextPrimary),
+          child: rankText,
         ),
       );
     }
@@ -175,6 +186,17 @@ class MyRank extends StatelessWidget {
         height: 44,
       );
     } else {
+      Widget rankText;
+      if (rank! > 9999) {
+        rankText =
+            Text(rank.toString(), style: TextStyles.fs12w800cTextPrimary);
+      } else if (rank! > 999) {
+        rankText =
+            Text(rank.toString(), style: TextStyles.fs16w700cTextPrimary);
+      } else {
+        rankText =
+            Text(rank.toString(), style: TextStyles.fs20w800cTextPrimary);
+      }
       return Container(
         width: 44,
         height: 44,
@@ -183,7 +205,7 @@ class MyRank extends StatelessWidget {
           borderRadius: BorderRadius.all(Radius.circular(22)),
         ),
         child: Center(
-          child: Text(rank.toString(), style: TextStyles.fs20w800cTextPrimary),
+          child: rankText,
         ),
       );
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -454,6 +454,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: bd9c475d9aae256369edacafc29d1e74c81f78a10cdcdacbbbc9e3c43d009e4a
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.4"
   flutter_native_splash:
     dependency: "direct main"
     description:
@@ -888,6 +896,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.2"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: ef2a1298144e3f985cc736b22e0ccdaf188b5b3970648f2d9dc13efd1d9df051
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.2"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   optimize_battery: ^0.0.4
   cached_network_image: ^3.4.0
   flutter_svg: ^2.0.10+1
+  flutter_markdown: ^0.7.4
 
 
 dev_dependencies:


### PR DESCRIPTION
## 작업 내용*
- 앱 실행시 팝업창으로 띄어야 한다.
- 하드 코딩이 아닌 서버에서 팝업 정보를 받와서 띄운다.
- 닫기 버튼과 오늘 하루 보지 않기 버튼을 만든다.
- 공지사항 화면을 만든다.
- 이벤트 클릭시 관련된 공지사항 페이지로 연결시킨다.
- userId 표시하는 기능 추가
- 처음 앱을 실행 했을 때는 땅이 먹어지는 기능 추가
- 랭킹의 숫자가 길어지면 폰트 사이즈를 줄이는 기능 추가
- 백그라운드 모드 마지막 상태 유지
## 고민한 내용*
- 이벤트시 유저 식별을 위해 userId 를 띄우는 기능을 추가했다.
- secureStorage를 사용해서 오늘 하루보지 않기 기능을 구현했다.
- 랭킹이 낮은 경우 숫자가 길어 폰크가 깨지는 오류가 발생하여 길이가 긴 경우에는 폰트크기를 줄였다
- 앱을 처음 설치한 사용자가 땅이 안먹어지는 것을 보고 이탈 할 수도 있겠다 생각하여 최초 실행시에는 땅이 먹어지도록 수정 하였다
- 앱을 껏다 키면 백그라운드 모드가 꺼진 상태로 츄지되서 마지막 백그라운드 상태가 유지 될 수 있도록 수정 하였다.
- 이벤트 팝을 클릭한 비율을 분석하기 위해 이벤트 팝업을 클릭한 횟수를 집계할 수 있게 구현하였다.
- 공지사항도 마찬가지로 공지사항 조회수를 기록할 수 있게 구현하였다.
- 공지사항은 마크 다운 모듈을 적용하여 마크 다운 형식의 텍스트를 렌더링 할 수 있게 하였다.

## 리뷰 요구사항
- 리뷰할 때 중점적으로 봐줬으면 하는 내용들
## 스크린샷
| ![Screenshot_20241014_210507](https://github.com/user-attachments/assets/c381d1ad-0368-429d-8069-e895247a223f) | ![Simulator Screenshot - iPhone 15 Pro - 2024-10-14 at 14 27 36](https://github.com/user-attachments/assets/d6aab6fb-c608-4e38-bffd-09886a892ba8) | ![IMG_0940](https://github.com/user-attachments/assets/d93e0abd-518d-41bf-9018-aa9cce603487) |
|------|------|------|


