### PR TITLE
M3-411 default 이미지 변경

### DIFF
--- a/lib/controllers/user_info_controller.dart
+++ b/lib/controllers/user_info_controller.dart
@@ -252,6 +252,7 @@ class UserInfoController extends GetxController {
 
   void deleteImage() {
     profileImage.value = null;
+    imageS3Url.value = "";
     update();
   }
 }


### PR DESCRIPTION
## 작업 내용*
- 이미지 수정에서 x를 누르면 default 이미지가 보여지도록 수정

## 고민한 내용*
- 원래 로직이  imageS3Url이 ""이면 default image를 보여주도록 설정은 되어있었는데, x를 누르면 수정하기 전의 이미지로 돌아가도록 되어 있어서 이 부분으로 들어가지 않고 있었음. 
- 이 조건문으로 들어가도록 수정함

