### PR TITLE
M3-422 누적 랭킹을 확인 할 수 있는 토글 추가

### DIFF
--- a/lib/controllers/ranking_controller.dart
+++ b/lib/controllers/ranking_controller.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 
 import '../constants/app_colors.dart';
 import '../enums/ranking_kind.dart';
+import '../enums/ranking_type.dart';
 import '../models/ranking.dart';
 import '../models/user_pixel_count.dart';
 import '../service/ranking_service.dart';
@@ -22,6 +23,7 @@ class RankingController extends GetxController {
 
   late Rx<Ranking> myRanking;
   final RxInt selectedType = 0.obs;
+  final Rx<RankingType> rankingType = RankingType.current.obs;
   final RxList rankings = [].obs;
 
   final RxDouble t = 0.0.obs;
@@ -47,10 +49,11 @@ class RankingController extends GetxController {
   _initRanking() async {
     isLoading.value = true;
     List<Ranking> rankings =
-        await rankingService.getAllUserRanking(selectedWeek);
+        await rankingService.getAllUserRanking(selectedWeek, rankingType.value);
     Ranking myRanking = await rankingService.getUserRanking(
       UserManager().getUserId()!,
       selectedWeek,
+      rankingType.value,
     );
     this.rankings.assignAll(rankings);
     this.myRanking = myRanking.obs;
@@ -66,10 +69,14 @@ class RankingController extends GetxController {
     List<Ranking> rankings;
     Ranking myRanking;
     if (selectedType.value == 0) {
-      rankings = await rankingService.getAllUserRanking(selectedWeek);
+      rankings = await rankingService.getAllUserRanking(
+        selectedWeek,
+        rankingType.value,
+      );
       myRanking = await rankingService.getUserRanking(
         UserManager().getUserId()!,
         selectedWeek,
+        rankingType.value,
       );
     } else {
       int? communityId =
@@ -123,8 +130,21 @@ class RankingController extends GetxController {
     return selectedType.value;
   }
 
+  getRankingType() {
+    return rankingType.value;
+  }
+
   updateSelectedType(int type) {
     selectedType.value = type;
+    _updateRankingWithProgressIndicator();
+  }
+
+  updateRakingType(int type) {
+    if (type == 0) {
+      rankingType.value = RankingType.current;
+    } else {
+      rankingType.value = RankingType.accumulate;
+    }
     _updateRankingWithProgressIndicator();
   }
 

--- a/lib/enums/ranking_type.dart
+++ b/lib/enums/ranking_type.dart
@@ -1,0 +1,4 @@
+enum RankingType {
+  current,
+  accumulate,
+}

--- a/lib/screens/ranking_screen.dart
+++ b/lib/screens/ranking_screen.dart
@@ -5,7 +5,7 @@ import '../constants/app_colors.dart';
 import '../controllers/ranking_controller.dart';
 import '../widgets/ranking/my_ranking_info.dart';
 import '../widgets/ranking/ranking_list.dart';
-import '../widgets/ranking/week_selector.dart';
+import '../widgets/ranking/ranking_option_selector.dart';
 
 class RankingScreen extends StatelessWidget {
   const RankingScreen({super.key});
@@ -19,7 +19,7 @@ class RankingScreen extends StatelessWidget {
           padding: EdgeInsets.symmetric(vertical: 0, horizontal: 10),
           child: Column(
             children: [
-              WeekSelector(),
+              RankingOptionSelector(),
               MyRankingInfo(),
               SizedBox(
                 height: 20,

--- a/lib/service/ranking_service.dart
+++ b/lib/service/ranking_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 
+import '../enums/ranking_type.dart';
 import '../models/ranking.dart';
 import '../utils/dio_service.dart';
 
@@ -13,9 +14,14 @@ class RankingService {
     return _instance;
   }
 
-  getAllUserRanking(DateTime lookupDate) async {
+  getAllUserRanking(DateTime lookupDate, RankingType type) async {
+    String path = '/ranking/user';
+    if (type == RankingType.accumulate) {
+      path = '/ranking/accumulate/user';
+    }
+
     var response = await dio.get(
-      '/ranking/user',
+      path,
       queryParameters: {
         'lookup-date':
             '${lookupDate.year}-${lookupDate.month.toString().padLeft(2, '0')}-${lookupDate.day.toString().padLeft(2, '0')}',
@@ -25,9 +31,14 @@ class RankingService {
     return Ranking.listFromJsonUser(response.data['data']);
   }
 
-  getUserRanking(int userId, DateTime lookupDate) async {
+  getUserRanking(int userId, DateTime lookupDate, RankingType type) async {
+    String path = '/ranking/user';
+    if (type == RankingType.accumulate) {
+      path = '/ranking/accumulate/user';
+    }
+
     var response = await dio.get(
-      '/ranking/user/${userId.toString()}',
+      '$path/${userId.toString()}',
       queryParameters: {
         'lookup-date':
             '${lookupDate.year}-${lookupDate.month.toString().padLeft(2, '0')}-${lookupDate.day.toString().padLeft(2, '0')}',

--- a/lib/widgets/common/app_bar.dart
+++ b/lib/widgets/common/app_bar.dart
@@ -3,7 +3,7 @@ import 'package:get/get.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
-import '../ranking/ranking_type_toggle_button.dart';
+import '../ranking/selected_type_toggle_button.dart';
 
 class MapAppBar extends StatelessWidget {
   const MapAppBar({super.key});
@@ -24,7 +24,7 @@ class RankingAppBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return AppBar(
       backgroundColor: AppColors.background,
-      title: RankingTypeToggleButton(),
+      title: SelectedTypeToggleButton(),
     );
   }
 }

--- a/lib/widgets/ranking/ranking_option_selector.dart
+++ b/lib/widgets/ranking/ranking_option_selector.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:ground_flip/widgets/ranking/week_selector.dart';
+
+import 'ranking_type_toggle_button.dart';
+
+class RankingOptionSelector extends StatelessWidget {
+  static String rankingGuideUrl =
+      'https://autumn-blouse-355.notion.site/b90c1f81e247499ab244137634b066bc?pvs=4';
+
+  const RankingOptionSelector({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: 10, horizontal: 10),
+      child: Row(
+        children: [
+          WeekSelector(),
+          Spacer(),
+          RankingTypeToggleButton(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/ranking/ranking_option_selector.dart
+++ b/lib/widgets/ranking/ranking_option_selector.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:ground_flip/widgets/ranking/week_selector.dart';
 
 import 'ranking_type_toggle_button.dart';
+import 'week_selector.dart';
 
 class RankingOptionSelector extends StatelessWidget {
   static String rankingGuideUrl =

--- a/lib/widgets/ranking/ranking_type_toggle_button.dart
+++ b/lib/widgets/ranking/ranking_type_toggle_button.dart
@@ -13,55 +13,60 @@ class RankingTypeToggleButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final RankingController rankingController = Get.find<RankingController>();
     return Obx(() {
-      return Center(
-        child: AnimatedToggleSwitch<int>.size(
-          current:
-              rankingController.getRankingType() == RankingType.current ? 0 : 1,
-          style: ToggleStyle(
-            backgroundColor: AppColors.backgroundSecondary,
-            indicatorColor: AppColors.buttonColor,
-            borderColor: Colors.transparent,
-            borderRadius: BorderRadius.circular(24.0),
-            indicatorBorderRadius: BorderRadius.circular(24.0),
-          ),
-          values: const [0, 1],
-          iconOpacity: 1.0,
-          selectedIconScale: 1.0,
-          indicatorSize: Size.fromWidth(50),
-          height: 28,
-          iconAnimationType: AnimationType.onHover,
-          styleAnimationType: AnimationType.onHover,
-          spacing: 2.0,
-          customSeparatorBuilder: (context, local, global) {
-            final opacity = ((global.position - local.position).abs() - 0.5)
-                .clamp(0.0, 1.0);
-            return VerticalDivider(
-              indent: 10.0,
-              endIndent: 10.0,
-              color: Colors.white38.withOpacity(opacity),
-            );
-          },
-          customIconBuilder: (context, local, global) {
-            final text = const ['현재', '누적'][local.index];
-            return Center(
-              child: Text(
-                text,
-                style: TextStyle(
-                  color: Color.lerp(
-                    Colors.white,
-                    Colors.black,
-                    local.animationValue,
+      if (rankingController.getSelectedType() == 0) {
+        return Center(
+          child: AnimatedToggleSwitch<int>.size(
+            current: rankingController.getRankingType() == RankingType.current
+                ? 0
+                : 1,
+            style: ToggleStyle(
+              backgroundColor: AppColors.backgroundSecondary,
+              indicatorColor: AppColors.buttonColor,
+              borderColor: Colors.transparent,
+              borderRadius: BorderRadius.circular(24.0),
+              indicatorBorderRadius: BorderRadius.circular(24.0),
+            ),
+            values: const [0, 1],
+            iconOpacity: 1.0,
+            selectedIconScale: 1.0,
+            indicatorSize: Size.fromWidth(50),
+            height: 28,
+            iconAnimationType: AnimationType.onHover,
+            styleAnimationType: AnimationType.onHover,
+            spacing: 2.0,
+            customSeparatorBuilder: (context, local, global) {
+              final opacity = ((global.position - local.position).abs() - 0.5)
+                  .clamp(0.0, 1.0);
+              return VerticalDivider(
+                indent: 10.0,
+                endIndent: 10.0,
+                color: Colors.white38.withOpacity(opacity),
+              );
+            },
+            customIconBuilder: (context, local, global) {
+              final text = const ['현재', '누적'][local.index];
+              return Center(
+                child: Text(
+                  text,
+                  style: TextStyle(
+                    color: Color.lerp(
+                      Colors.white,
+                      Colors.black,
+                      local.animationValue,
+                    ),
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
                   ),
-                  fontSize: 14,
-                  fontWeight: FontWeight.w600,
                 ),
-              ),
-            );
-          },
-          borderWidth: 0.0,
-          onChanged: (i) => rankingController.updateRakingType(i),
-        ),
-      );
+              );
+            },
+            borderWidth: 0.0,
+            onChanged: (i) => rankingController.updateRakingType(i),
+          ),
+        );
+      } else {
+        return SizedBox();
+      }
     });
   }
 }

--- a/lib/widgets/ranking/ranking_type_toggle_button.dart
+++ b/lib/widgets/ranking/ranking_type_toggle_button.dart
@@ -4,9 +4,10 @@ import 'package:get/get.dart';
 
 import '../../constants/app_colors.dart';
 import '../../controllers/ranking_controller.dart';
+import '../../enums/ranking_type.dart';
 
 class RankingTypeToggleButton extends StatelessWidget {
-  RankingTypeToggleButton({super.key});
+  const RankingTypeToggleButton({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -14,7 +15,8 @@ class RankingTypeToggleButton extends StatelessWidget {
     return Obx(() {
       return Center(
         child: AnimatedToggleSwitch<int>.size(
-          current: rankingController.getSelectedType(),
+          current:
+              rankingController.getRankingType() == RankingType.current ? 0 : 1,
           style: ToggleStyle(
             backgroundColor: AppColors.backgroundSecondary,
             indicatorColor: AppColors.buttonColor,
@@ -25,8 +27,8 @@ class RankingTypeToggleButton extends StatelessWidget {
           values: const [0, 1],
           iconOpacity: 1.0,
           selectedIconScale: 1.0,
-          indicatorSize: Size.fromWidth(175),
-          height: 48,
+          indicatorSize: Size.fromWidth(50),
+          height: 28,
           iconAnimationType: AnimationType.onHover,
           styleAnimationType: AnimationType.onHover,
           spacing: 2.0,
@@ -40,7 +42,7 @@ class RankingTypeToggleButton extends StatelessWidget {
             );
           },
           customIconBuilder: (context, local, global) {
-            final text = const ['개인', '그룹'][local.index];
+            final text = const ['현재', '누적'][local.index];
             return Center(
               child: Text(
                 text,
@@ -50,14 +52,14 @@ class RankingTypeToggleButton extends StatelessWidget {
                     Colors.black,
                     local.animationValue,
                   ),
-                  fontSize: 16,
+                  fontSize: 14,
                   fontWeight: FontWeight.w600,
                 ),
               ),
             );
           },
           borderWidth: 0.0,
-          onChanged: (i) => rankingController.updateSelectedType(i),
+          onChanged: (i) => rankingController.updateRakingType(i),
         ),
       );
     });

--- a/lib/widgets/ranking/selected_type_toggle_button.dart
+++ b/lib/widgets/ranking/selected_type_toggle_button.dart
@@ -1,0 +1,65 @@
+import 'package:animated_toggle_switch/animated_toggle_switch.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../constants/app_colors.dart';
+import '../../controllers/ranking_controller.dart';
+
+class SelectedTypeToggleButton extends StatelessWidget {
+  SelectedTypeToggleButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final RankingController rankingController = Get.find<RankingController>();
+    return Obx(() {
+      return Center(
+        child: AnimatedToggleSwitch<int>.size(
+          current: rankingController.getSelectedType(),
+          style: ToggleStyle(
+            backgroundColor: AppColors.backgroundSecondary,
+            indicatorColor: AppColors.buttonColor,
+            borderColor: Colors.transparent,
+            borderRadius: BorderRadius.circular(24.0),
+            indicatorBorderRadius: BorderRadius.circular(24.0),
+          ),
+          values: const [0, 1],
+          iconOpacity: 1.0,
+          selectedIconScale: 1.0,
+          indicatorSize: Size.fromWidth(175),
+          height: 48,
+          iconAnimationType: AnimationType.onHover,
+          styleAnimationType: AnimationType.onHover,
+          spacing: 2.0,
+          customSeparatorBuilder: (context, local, global) {
+            final opacity = ((global.position - local.position).abs() - 0.5)
+                .clamp(0.0, 1.0);
+            return VerticalDivider(
+              indent: 10.0,
+              endIndent: 10.0,
+              color: Colors.white38.withOpacity(opacity),
+            );
+          },
+          customIconBuilder: (context, local, global) {
+            final text = const ['개인', '그룹'][local.index];
+            return Center(
+              child: Text(
+                text,
+                style: TextStyle(
+                  color: Color.lerp(
+                    Colors.white,
+                    Colors.black,
+                    local.animationValue,
+                  ),
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            );
+          },
+          borderWidth: 0.0,
+          onChanged: (i) => rankingController.updateSelectedType(i),
+        ),
+      );
+    });
+  }
+}

--- a/lib/widgets/ranking/week_selector.dart
+++ b/lib/widgets/ranking/week_selector.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
-import 'package:ground_flip/widgets/ranking/week_wheel_picker.dart';
 import 'package:intl/intl.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
 import '../../controllers/ranking_controller.dart';
 import '../../enums/ranking_type.dart';
+import 'week_wheel_picker.dart';
 
 class WeekSelector extends StatelessWidget {
   const WeekSelector({super.key});

--- a/lib/widgets/ranking/week_selector.dart
+++ b/lib/widgets/ranking/week_selector.dart
@@ -1,59 +1,61 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
+import 'package:ground_flip/widgets/ranking/week_wheel_picker.dart';
+import 'package:intl/intl.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
 import '../../controllers/ranking_controller.dart';
-import 'ranking_type_toggle_button.dart';
-import 'week_wheel_picker.dart';
+import '../../enums/ranking_type.dart';
 
 class WeekSelector extends StatelessWidget {
-  static String rankingGuideUrl =
-      'https://autumn-blouse-355.notion.site/b90c1f81e247499ab244137634b066bc?pvs=4';
-
   const WeekSelector({super.key});
 
   @override
   Widget build(BuildContext context) {
     final RankingController rankingController = Get.find<RankingController>();
-
-    return Padding(
-      padding: EdgeInsets.symmetric(vertical: 10, horizontal: 10),
-      child: Row(
-        children: [
-          GestureDetector(
-            onTap: () {
+    return Obx(() {
+      if ((!(rankingController.rankingType.value == RankingType.accumulate &&
+          rankingController.getSelectedType() == 0))) {
+        return GestureDetector(
+          onTap: () {
+            if (!(rankingController.rankingType.value ==
+                    RankingType.accumulate &&
+                rankingController.getSelectedType() == 0)) {
               Get.bottomSheet(
                 WeekWheelPicker(),
                 backgroundColor: AppColors.backgroundSecondary,
                 enterBottomSheetDuration: Duration(milliseconds: 100),
                 exitBottomSheetDuration: Duration(milliseconds: 100),
               );
-            },
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Obx(() {
-                  return Text(
-                    rankingController.selectedWeekString.value,
-                    style: TextStyles.fs17w700cTextPrimary,
-                  );
-                }),
-                SizedBox(
-                  width: 5,
-                ),
-                Image.asset(
-                  "assets/images/chevron_down.png",
-                  width: 20,
-                  height: 20,
-                ),
-              ],
-            ),
+            }
+          },
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Obx(() {
+                return Text(
+                  rankingController.selectedWeekString.value,
+                  style: TextStyles.fs17w700cTextPrimary,
+                );
+              }),
+              SizedBox(
+                width: 5,
+              ),
+              Image.asset(
+                "assets/images/chevron_down.png",
+                width: 20,
+                height: 20,
+              ),
+            ],
           ),
-          Spacer(),
-          RankingTypeToggleButton(),
-        ],
-      ),
-    );
+        );
+      } else {
+        return Text(
+          DateFormat('yyyy년 MM월 dd일').format(DateTime.now()),
+          style: TextStyles.fs17w600cTextPrimary,
+        );
+      }
+    });
   }
 }

--- a/lib/widgets/ranking/week_selector.dart
+++ b/lib/widgets/ranking/week_selector.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/text_styles.dart';
 import '../../controllers/ranking_controller.dart';
+import 'ranking_type_toggle_button.dart';
 import 'week_wheel_picker.dart';
 
 class WeekSelector extends StatelessWidget {
@@ -18,7 +18,7 @@ class WeekSelector extends StatelessWidget {
     final RankingController rankingController = Get.find<RankingController>();
 
     return Padding(
-      padding: EdgeInsets.symmetric(vertical: 0, horizontal: 0),
+      padding: EdgeInsets.symmetric(vertical: 10, horizontal: 10),
       child: Row(
         children: [
           GestureDetector(
@@ -51,13 +51,7 @@ class WeekSelector extends StatelessWidget {
             ),
           ),
           Spacer(),
-          IconButton(
-            icon: Icon(Icons.info_outline),
-            color: AppColors.buttonColor,
-            onPressed: () {
-              launchUrl(Uri.parse(rankingGuideUrl));
-            },
-          ),
+          RankingTypeToggleButton(),
         ],
       ),
     );


### PR DESCRIPTION
## 작업 내용*
- 누적 랭킹을 확인 할 수 있는 토글 추가

## 고민한 내용*
- 개인전 모드에서 누적 픽셀 랭킹을 확인 할 수 있는 기능을 추하였다.
- 누적 픽셀은 주차별로 초기화 되는 점수가 아니기에 주차 별로 확인 할 수 있는 기능을 비활성화 시키고 현재 날짜를 띄어주는 방식으로 수정 하였다.

## 스크린샷
 ![Screenshot_20250105_174510](https://github.com/user-attachments/assets/56de157c-f39e-4600-8a7d-947ea4fc81b7) 

