### PR TITLE
M3-424 지도 화면에서 api 호출 빈도 최적화

### DIFF
--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -61,6 +61,7 @@ class MapController extends SuperController {
 
   final box = GetStorage();
 
+  late CameraPosition lastStoppedCameraPosition;
   late CameraPosition currentCameraPosition;
   late Map<String, int> latestPixel;
 
@@ -178,14 +179,29 @@ class MapController extends SuperController {
     if (!isBottomSheetShowUp) {
       _cameraIdleTimer = Timer(Duration(milliseconds: 300), () {
         final currentZoomLevel = currentCameraPosition.zoom;
-        final moveAmountThreshold = _calculateThresholdByZoom(currentZoomLevel);
+        final calculatedThreshold = _calculateThresholdByZoom(currentZoomLevel);
+        final zoomLevelChanged = _hasZoomChanged(currentZoomLevel);
 
+        if (zoomLevelChanged || _cameraMovedOverThreshold(calculatedThreshold)) {
+          updateMap();
+        }
 
-        // updateMap();
+        _lastZoomLevel = currentCameraPosition.zoom;
+        lastStoppedCameraPosition = currentCameraPosition;
       });
     }
   }
 
+  bool _cameraMovedOverThreshold(double threshold) {
+    final distance = _calculateDistance(currentCameraPosition.target, lastStoppedCameraPosition.target);
+    return distance > threshold;
+  }
+
+
+  bool _hasZoomChanged(double currentZoom) {
+    if (_lastZoomLevel == null) return true;
+    return (currentZoom - _lastZoomLevel!).abs() > zoomChangeThreshold;
+  }
 
   double _calculateThresholdByZoom(double zoom) {
     const double baseZoomLevel = 16;
@@ -208,6 +224,7 @@ class MapController extends SuperController {
       ),
       zoom: 16.0,
     );
+    lastStoppedCameraPosition = currentCameraPosition;
     googleMapController?.animateCamera(
       CameraUpdate.newCameraPosition(currentCameraPosition),
     );

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -52,8 +52,9 @@ class MapController extends SuperController {
   static const String backgroundModeStatusKey = 'backgroundModeStatusKey';
   static const String firstLaunchKey = 'firstLaunchKey';
   static const double defaultMapUpdateThreshold = 300;  // 줌 레벨 16 기준 threshold
-  static const double zoomChangeThreshold = 0.5;  // 줌 변경 감지 임계값
-  
+  static const double zoomChangeThreshold = 0.3;  // 줌 변경 감지 임계값
+
+
   late final String mapStyle;
 
   GoogleMapController? googleMapController;
@@ -176,9 +177,20 @@ class MapController extends SuperController {
   void onCameraIdle() {
     if (!isBottomSheetShowUp) {
       _cameraIdleTimer = Timer(Duration(milliseconds: 300), () {
-        updateMap();
+        final currentZoomLevel = currentCameraPosition.zoom;
+        final moveAmountThreshold = _calculateThresholdByZoom(currentZoomLevel);
+
+
+        // updateMap();
       });
     }
+  }
+
+
+  double _calculateThresholdByZoom(double zoom) {
+    const double baseZoomLevel = 16;
+    double threshold = defaultMapUpdateThreshold * math.pow(2, (baseZoomLevel - zoom));
+    return threshold.clamp(50, 2000);
   }
 
   void updateCameraPosition(CameraPosition newCameraPosition) async {

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -61,6 +61,7 @@ class MapController extends SuperController {
 
   final box = GetStorage();
 
+  late CameraPosition lastStoppedCameraPosition;
   late CameraPosition currentCameraPosition;
   late Map<String, int> latestPixel;
 
@@ -178,14 +179,28 @@ class MapController extends SuperController {
     if (!isBottomSheetShowUp) {
       _cameraIdleTimer = Timer(Duration(milliseconds: 300), () {
         final currentZoomLevel = currentCameraPosition.zoom;
-        final moveAmountThreshold = _calculateThresholdByZoom(currentZoomLevel);
+        final calculatedThreshold = _calculateThresholdByZoom(currentZoomLevel);
+        final zoomLevelChanged = _hasZoomChanged(currentZoomLevel);
 
+        if (zoomLevelChanged || _cameraMovedOverThreshold(calculatedThreshold)) {
+          updateMap();
+        }
 
-        // updateMap();
+        lastStoppedCameraPosition = currentCameraPosition;
       });
     }
   }
 
+  bool _cameraMovedOverThreshold(double threshold) {
+    final distance = _calculateDistance(currentCameraPosition.target, lastStoppedCameraPosition.target);
+    return distance > threshold;
+  }
+
+
+  bool _hasZoomChanged(double currentZoom) {
+    if (_lastZoomLevel == null) return true;
+    return (currentZoom - _lastZoomLevel!).abs() > zoomChangeThreshold;
+  }
 
   double _calculateThresholdByZoom(double zoom) {
     const double baseZoomLevel = 16;
@@ -195,6 +210,7 @@ class MapController extends SuperController {
 
   void updateCameraPosition(CameraPosition newCameraPosition) async {
     currentCameraPosition = newCameraPosition;
+    _lastZoomLevel = newCameraPosition.zoom;
     _cameraIdleTimer?.cancel();
   }
 
@@ -208,6 +224,7 @@ class MapController extends SuperController {
       ),
       zoom: 16.0,
     );
+    lastStoppedCameraPosition = currentCameraPosition;
     googleMapController?.animateCamera(
       CameraUpdate.newCameraPosition(currentCameraPosition),
     );

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -179,14 +179,29 @@ class MapController extends SuperController {
     if (!isBottomSheetShowUp) {
       _cameraIdleTimer = Timer(Duration(milliseconds: 300), () {
         final currentZoomLevel = currentCameraPosition.zoom;
-        final moveAmountThreshold = _calculateThresholdByZoom(currentZoomLevel);
+        final calculatedThreshold = _calculateThresholdByZoom(currentZoomLevel);
+        final zoomLevelChanged = _hasZoomChanged(currentZoomLevel);
 
+        if (zoomLevelChanged || _cameraMovedOverThreshold(calculatedThreshold)) {
+          updateMap();
+        }
 
+        lastStoppedCameraPosition = currentCameraPosition;
         // updateMap();
       });
     }
   }
 
+  bool _cameraMovedOverThreshold(double threshold) {
+    final distance = _calculateDistance(currentCameraPosition.target, lastStoppedCameraPosition.target);
+    return distance > threshold;
+  }
+
+
+  bool _hasZoomChanged(double currentZoom) {
+    if (_lastZoomLevel == null) return true;
+    return (currentZoom - _lastZoomLevel!).abs() > zoomChangeThreshold;
+  }
 
   double _calculateThresholdByZoom(double zoom) {
     const double baseZoomLevel = 16;

--- a/lib/controllers/map_controller.dart
+++ b/lib/controllers/map_controller.dart
@@ -51,7 +51,9 @@ class MapController extends SuperController {
   static const double lonPerPixel = 0.000909;
   static const String backgroundModeStatusKey = 'backgroundModeStatusKey';
   static const String firstLaunchKey = 'firstLaunchKey';
-
+  static const double defaultMapUpdateThreshold = 300;  // 줌 레벨 16 기준 threshold
+  static const double zoomChangeThreshold = 0.5;  // 줌 변경 감지 임계값
+  
   late final String mapStyle;
 
   GoogleMapController? googleMapController;
@@ -90,6 +92,8 @@ class MapController extends SuperController {
   RxBool isRunning = false.obs;
 
   RxBool isBackgroundEnabled = false.obs;
+
+  double? _lastZoomLevel;
 
   @override
   void onInit() async {


### PR DESCRIPTION
## 작업 내용*
- 기존 지도화면에서 과도한 픽셀 관련 API 호출을 최적화함.

## 고민한 내용*
**원인**

<img width="222" alt="image" src="https://github.com/user-attachments/assets/ea446e0c-f4d5-4090-bc33-fa5d616f4ef8" />

- 기존 로직은 카메라가 약 0.3초간 idle하면 무조건 API 요청을 하게 되어있었다.
- 때문에 아주 조금만 움직여도 호출이 일어났는데, 특히 GPS 좌표를 그대로 트래킹하는 현재 로직 상 실제로 사용자가 움직이지 않더라도 GPS 신호가 바뀔때마다 호출이 일어났다.

**해결**
<img width="219" alt="image" src="https://github.com/user-attachments/assets/e4852c01-1156-4a94-a763-c97c8157d7d4" />

- 총 두 가지 threshold를 도입했다.
- 첫 번째는 마지막 위치 대비 움직인 거리를 나타내는 threashold
- 두 번째는 마지막 줌 레벨 대비 변화한 줌 량을 나타내는 threshold

- 이 두 가지를 조합하여 줌 레벨, 카메라 센터가 일정 이상 변했을 때만 API를 호출한다.
- 기본 줌 레벨인 16에선 threshold가 300m이며 줌 레벨 1 당 약 2배씩 지수 스케일로 축소/확대되므로 이를 계산하는 함수를 만들었다.
