### PR TITLE
M3-425 그룹 랭킹에서 그룹 클릭시 상세 정보 창 띄우기

### DIFF
--- a/lib/constants/text_styles.dart
+++ b/lib/constants/text_styles.dart
@@ -158,6 +158,12 @@ class TextStyles {
     fontWeight: FontWeight.w900,
   );
 
+  static TextStyle fs24w600cTextPrimary = TextStyle(
+    color: AppColors.textPrimary,
+    fontSize: 24,
+    fontWeight: FontWeight.w600,
+  );
+
   static TextStyle fs32w400cTextSecondary = TextStyle(
     color: AppColors.textSecondary,
     fontSize: 32,

--- a/lib/controllers/ranking_controller.dart
+++ b/lib/controllers/ranking_controller.dart
@@ -5,18 +5,22 @@ import 'package:get/get.dart';
 import '../constants/app_colors.dart';
 import '../enums/ranking_kind.dart';
 import '../enums/ranking_type.dart';
+import '../models/community.dart';
 import '../models/ranking.dart';
 import '../models/user_pixel_count.dart';
+import '../service/community_service.dart';
 import '../service/ranking_service.dart';
 import '../service/user_service.dart';
 import '../utils/date_handler.dart';
 import '../utils/user_manager.dart';
+import '../widgets/ranking/community_info_bottom_sheet.dart';
 import '../widgets/ranking/ranking_bottom_sheet.dart';
 import 'my_page_controller.dart';
 
 class RankingController extends GetxController {
   final RankingService rankingService = RankingService();
   final UserService userService = UserService();
+  final CommunityService communityService = CommunityService();
   final ScrollController scrollController = ScrollController();
 
   final RxBool isLoading = true.obs;
@@ -159,20 +163,39 @@ class RankingController extends GetxController {
   void openRankingBottomSheet(Ranking ranking) async {
     FirebaseAnalytics.instance.logEvent(name: "ranking_element_click");
     if (ranking.kind == RankingKind.user) {
-      UserPixelCount pixelCount =
-          await userService.getAnotherUserPixelCount(null, ranking.id);
-      Get.bottomSheet(
-        RankingBottomSheet(
-          userId: ranking.id,
-          nickname: ranking.name!,
-          profileImageUrl: ranking.profileImageUrl,
-          currentPixelCount: pixelCount.currentPixelCount!,
-          accumulatePixelCount: pixelCount.accumulatePixelCount!,
-        ),
-        backgroundColor: AppColors.background,
-        enterBottomSheetDuration: Duration(milliseconds: 100),
-        exitBottomSheetDuration: Duration(milliseconds: 100),
-      );
+      await openUserInfo(ranking);
+    } else {
+      await openCommunityInfo(ranking);
     }
+  }
+
+  Future<void> openUserInfo(Ranking ranking) async {
+    UserPixelCount pixelCount =
+        await userService.getAnotherUserPixelCount(null, ranking.id);
+    Get.bottomSheet(
+      RankingBottomSheet(
+        userId: ranking.id,
+        nickname: ranking.name!,
+        profileImageUrl: ranking.profileImageUrl,
+        currentPixelCount: pixelCount.currentPixelCount!,
+        accumulatePixelCount: pixelCount.accumulatePixelCount!,
+      ),
+      backgroundColor: AppColors.background,
+      enterBottomSheetDuration: Duration(milliseconds: 100),
+      exitBottomSheetDuration: Duration(milliseconds: 100),
+    );
+  }
+
+  Future<void> openCommunityInfo(Ranking ranking) async {
+    Community community = await communityService.getCommunityInfo(ranking.id);
+    Get.bottomSheet(
+      CommunityInfoBottomSheet(
+        community: community,
+        communityId: ranking.id,
+      ),
+      backgroundColor: AppColors.background,
+      enterBottomSheetDuration: Duration(milliseconds: 100),
+      exitBottomSheetDuration: Duration(milliseconds: 100),
+    );
   }
 }

--- a/lib/screens/community_info_screen.dart
+++ b/lib/screens/community_info_screen.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 
 import '../constants/app_colors.dart';
 import '../controllers/community_info_controller.dart';
+import '../controllers/my_page_controller.dart';
 import '../widgets/community/community_action_button.dart';
 import '../widgets/community/community_image.dart';
 import '../widgets/community/community_info.dart';
@@ -23,6 +24,7 @@ class CommunityInfoScreen extends StatelessWidget {
     final CommunityInfoController communityInfoController =
         Get.put(CommunityInfoController());
     communityInfoController.init(communityId);
+    final MyPageController myPageController = Get.find<MyPageController>();
 
     return Scaffold(
       backgroundColor: Colors.black,
@@ -46,10 +48,10 @@ class CommunityInfoScreen extends StatelessWidget {
                 leading: IconButton(
                   icon: Icon(Icons.arrow_back_ios),
                   onPressed: () {
-                    if(communityInfoController.password.value != ""){
+                    if (communityInfoController.password.value != "") {
                       Get.back();
                       Get.back();
-                    }else{
+                    } else {
                       Get.back();
                     }
                   },
@@ -132,9 +134,11 @@ class CommunityInfoScreen extends StatelessWidget {
                       SizedBox(
                         height: 20,
                       ),
-                      SignUpCommunityButton(
-                        onTap: communityInfoController.signUpCommunity,
-                      ),
+                      if (myPageController.currentUserInfo.value.communityId ==
+                          null)
+                        SignUpCommunityButton(
+                          onTap: communityInfoController.signUpCommunity,
+                        ),
                       SizedBox(
                         height: 20,
                       ),

--- a/lib/widgets/ranking/community_info_bottom_sheet.dart
+++ b/lib/widgets/ranking/community_info_bottom_sheet.dart
@@ -1,0 +1,124 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../constants/app_colors.dart';
+import '../../constants/text_styles.dart';
+import '../../models/community.dart';
+import '../../screens/community_info_screen.dart';
+import '../community/community_info.dart';
+import '../community/community_record.dart';
+
+class CommunityInfoBottomSheet extends StatelessWidget {
+  const CommunityInfoBottomSheet({
+    super.key,
+    required this.community,
+    required this.communityId,
+  });
+
+  final Community community;
+  final int communityId;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 600,
+      height: 400,
+      child: Padding(
+        padding: const EdgeInsets.only(
+            top: 5.0, left: 20.0, right: 20.0, bottom: 20.0),
+        child: Column(
+          children: [
+            Center(
+              child: Container(
+                decoration: BoxDecoration(
+                  color: AppColors.backgroundThird,
+                  borderRadius: const BorderRadius.all(Radius.circular(10)),
+                ),
+                height: 4,
+                width: 40,
+                margin: const EdgeInsets.fromLTRB(0, 10, 0, 0),
+              ),
+            ),
+            SizedBox(
+              height: 10.0,
+            ),
+            Stack(
+              children: [
+                Positioned.fill(
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(20.0), // 이미지 둥근 모서리
+                    child: Image(
+                      image: CachedNetworkImageProvider(
+                          community.backgroundImageUrl),
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                ),
+                Container(
+                  width: double.infinity,
+                  height: 270,
+                  padding: EdgeInsets.all(16.0),
+                  color: Colors.black.withOpacity(0.5),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: Column(
+                    children: [
+                      Align(
+                        alignment: Alignment.bottomLeft,
+                        child: Text(community.name,
+                            style: TextStyles.fs24w600cTextPrimary),
+                      ),
+                      SizedBox(
+                        height: 10,
+                      ),
+                      CommunityInfo(
+                        memberCount: community.memberCount.obs,
+                        communityColor: community.communityColor.obs,
+                        weeklyRanking: community.communityRanking.obs,
+                      ),
+                      SizedBox(
+                        height: 20,
+                      ),
+                      CommunityRecord(
+                        currentPixelCount: community.currentPixelCount.obs,
+                        accumulatePixelCount:
+                            community.accumulatePixelCount.obs,
+                        maxPixelCount: community.maxPixelCount.obs,
+                        maxRankingCount: community.maxRanking.obs,
+                      ),
+                    ],
+                  ),
+                )
+              ],
+            ),
+            SizedBox(
+              height: 20,
+            ),
+            InkWell(
+              borderRadius: BorderRadius.all(Radius.circular(16)),
+              onTap: () {
+                Get.to(CommunityInfoScreen(communityId: communityId));
+              },
+              child: Ink(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(16),
+                  color: AppColors.primary,
+                ),
+                height: 60,
+                width: 1000,
+                child: Center(
+                  child: Text(
+                    "자세히 보기",
+                    style: TextStyles.fs17w600cTextBlack,
+                  ),
+                ),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/ranking/community_info_bottom_sheet.dart
+++ b/lib/widgets/ranking/community_info_bottom_sheet.dart
@@ -26,7 +26,11 @@ class CommunityInfoBottomSheet extends StatelessWidget {
       height: 400,
       child: Padding(
         padding: const EdgeInsets.only(
-            top: 5.0, left: 20.0, right: 20.0, bottom: 20.0),
+          top: 5.0,
+          left: 20.0,
+          right: 20.0,
+          bottom: 20.0,
+        ),
         child: Column(
           children: [
             Center(
@@ -50,7 +54,8 @@ class CommunityInfoBottomSheet extends StatelessWidget {
                     borderRadius: BorderRadius.circular(20.0), // 이미지 둥근 모서리
                     child: Image(
                       image: CachedNetworkImageProvider(
-                          community.backgroundImageUrl),
+                        community.backgroundImageUrl,
+                      ),
                       fit: BoxFit.cover,
                     ),
                   ),
@@ -67,8 +72,10 @@ class CommunityInfoBottomSheet extends StatelessWidget {
                     children: [
                       Align(
                         alignment: Alignment.bottomLeft,
-                        child: Text(community.name,
-                            style: TextStyles.fs24w600cTextPrimary),
+                        child: Text(
+                          community.name,
+                          style: TextStyles.fs24w600cTextPrimary,
+                        ),
                       ),
                       SizedBox(
                         height: 10,
@@ -90,7 +97,7 @@ class CommunityInfoBottomSheet extends StatelessWidget {
                       ),
                     ],
                   ),
-                )
+                ),
               ],
             ),
             SizedBox(
@@ -115,7 +122,7 @@ class CommunityInfoBottomSheet extends StatelessWidget {
                   ),
                 ),
               ),
-            )
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## 작업 내용*
- 랭킹 창에서 그룹 클릭시 상세 정보 모달이 나오는 기능 추가
## 고민한 내용*
- 기존 그룹 페이지에서 사용하던 위젯을 재활용하여 구현하였다.
- 자세히 보기 버튼을 만들어 그룹 페이지로 이동 할 수 있도록 하였고, 그룹에 가입하지 않은 상태라면 그룹에 가입할 수 있도록 구현하였다.

## 스크린샷
![Screenshot_20250107_211312](https://github.com/user-attachments/assets/c1544f24-ae9b-4624-86c1-c74df60c01ac)
